### PR TITLE
Fix invalid index page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,3 @@
-import { Link } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import Home from './Home';
 
-const { t } = useTranslation();
-
-<nav className="...">
-  {/* ... andere links ... */}
-  <Link to="/dashboard" className="...">
-    {t('dashboard.title')}
-  </Link>
-</nav> 
+export default Home;


### PR DESCRIPTION
## Summary
- clean up `src/pages/index.tsx` by exporting `Home`

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684062b35280832da054616f7239d97f