### PR TITLE
Add screenshot label to EN locale

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,7 +6,8 @@
   "terms": "Terms & Conditions",
   "contact": "Contact Us",
   "reportIssue": {
-    "title": "Report an Issue"
+    "title": "Report an Issue",
+    "screenshotLabel": "Screenshot (optional)"
   },
   "close": "Close",
   "loading": "Loading...",


### PR DESCRIPTION
## Summary
- include screenshot label in English locale

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `jq . public/locales/en/common.json`

------
https://chatgpt.com/codex/tasks/task_e_684065621d90832d8281be8091ecff63