### PR TITLE
Create `.env` from example

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your own values
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+# Optional: required for Sentry source map uploads
+SENTRY_AUTH_TOKEN=<your-sentry-auth-token>


### PR DESCRIPTION
## Summary
- add `.env` template for local development

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68407ede3f94832d87f245515b91d550