### PR TITLE
Fix Supabase client setup

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -11,8 +11,8 @@ import {
   validateResponse,
 } from '../utils/typeGuards';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);
 

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,8 +1,1 @@
-import { createClient } from '@supabase/supabase-js';
-
-// console.log('DEBUG SUPABASE_URL:', import.meta.env.VITE_SUPABASE_URL);
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey); 
+export { supabase } from './lib/supabase';


### PR DESCRIPTION
## Summary
- read Supabase url/key from `import.meta.env` in the main client
- re-export `supabase` from `supabaseClient.ts` to avoid duplicate logic

## Testing
- `npm run build`
- `npm run dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68409c8394d4832da0bde78f4a22f47f