### PR TITLE
Fix invite token param

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -29,7 +29,7 @@ const AppRoutes = () => {
           <Route path="/account" element={<Account />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/create-meetup" element={<CreateMeetup />} />
-          <Route path="/invite/:id" element={<Invite />} />
+          <Route path="/invite/:token" element={<Invite />} />
           <Route path="/respond/:token" element={<Respond />} />
           <Route path="/confirmed" element={<Confirmed />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />


### PR DESCRIPTION
## Summary
- fix path parameter name for Invite route

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68416fd16398832db58cfb3bdaa75fc6