### PR TITLE
Improve date picker styling

### DIFF
--- a/src/components/meetups/DateSelector.tsx
+++ b/src/components/meetups/DateSelector.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import DatePicker from 'react-datepicker';
+import DatePicker, { registerLocale } from 'react-datepicker';
 import { useTranslation } from 'react-i18next';
+import enGB from 'date-fns/locale/en-GB';
+import nl from 'date-fns/locale/nl';
 import { getHolidaysForDate } from '../../utils/holidays';
 
 /**
@@ -31,8 +33,11 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   setDateTimeOptions,
   error,
 }) => {
-  const { t } = useTranslation('meetup');
-  const dateLocale = undefined; // locale logic if needed
+  const { t, i18n } = useTranslation('meetup');
+
+  registerLocale('en-GB', enGB);
+  registerLocale('nl', nl);
+  const dateLocale = i18n.language === 'nl' ? 'nl' : 'en-GB';
 
   // Helper: get local date string in YYYY-MM-DD
   const getLocalDateString = (date: Date) =>
@@ -76,6 +81,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
           selected={null}
           onChange={handleDatePickerChange}
           locale={dateLocale}
+          className="anemi-datepicker"
           inline
           minDate={new Date()}
         />


### PR DESCRIPTION
## Summary
- apply custom calendar styles
- show Monday as start of the week

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails to build project)*

------
https://chatgpt.com/codex/tasks/task_e_684172942ae0832d9ef165c5846812b8