### PR TITLE
Highlight selected dates in DatePicker

### DIFF
--- a/src/components/meetups/DateSelector.tsx
+++ b/src/components/meetups/DateSelector.tsx
@@ -43,6 +43,13 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const getLocalDateString = (date: Date) =>
     date.getFullYear() + '-' + String(date.getMonth() + 1).padStart(2, '0') + '-' + String(date.getDate()).padStart(2, '0');
 
+  // Highlight dates that are already selected
+  const dayClassName = (date: Date) => {
+    const dateStr = getLocalDateString(date);
+    const exists = selectedDates.some(d => getLocalDateString(d) === dateStr);
+    return exists ? 'date-selected' : undefined;
+  };
+
   // Add or remove a date
   const handleDatePickerChange = (date: Date) => {
     const dateStr = getLocalDateString(date);
@@ -82,6 +89,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
           onChange={handleDatePickerChange}
           locale={dateLocale}
           className="anemi-datepicker"
+          dayClassName={dayClassName}
           inline
           minDate={new Date()}
         />

--- a/src/index.css
+++ b/src/index.css
@@ -275,6 +275,14 @@
   box-shadow: 0 2px 8px #ff914d44;
 }
 
+/* Highlight days already chosen when selecting multiple dates */
+.anemi-datepicker .date-selected {
+  background: #ff914d;
+  color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 8px #ff914d44;
+}
+
 .anemi-datepicker .react-datepicker__day--today {
   border-radius: 50%;
   border: 2px solid #1573ff;


### PR DESCRIPTION
## Summary
- highlight picked days in the meetup date selector
- add `.date-selected` style for DatePicker highlight

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: many TS errors due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684182fd2210832d905c30b469d2659c