### PR TITLE
Fix datepicker locale registration

### DIFF
--- a/src/components/meetups/DateSelector.tsx
+++ b/src/components/meetups/DateSelector.tsx
@@ -5,6 +5,10 @@ import { enGB } from 'date-fns/locale/en-GB';
 import { nl } from 'date-fns/locale/nl';
 import { getHolidaysForDate } from '../../utils/holidays';
 
+// Register locales once when the module is loaded
+registerLocale('en-GB', enGB);
+registerLocale('nl', nl);
+
 /**
  * DateSelector component for selecting dates and times for a meetup.
  * Handles date picking, time slot selection, and validation.
@@ -35,8 +39,6 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
 }) => {
   const { t, i18n } = useTranslation('meetup');
 
-  registerLocale('en-GB', enGB);
-  registerLocale('nl', nl);
   const dateLocale = i18n.language === 'nl' ? 'nl' : 'en-GB';
 
   // Helper: get local date string in YYYY-MM-DD


### PR DESCRIPTION
## Summary
- ensure `DateSelector` registers locales only once

## Testing
- `npx eslint . --ext ts,tsx --config .eslintrc.cjs --report-unused-disable-directives --max-warnings 0` *(fails: config not compatible with eslint 9)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684182fe0d50832d8acf753001b2026b