### PR TITLE
Use stable keys for selected dates

### DIFF
--- a/src/components/meetups/DateSelector.tsx
+++ b/src/components/meetups/DateSelector.tsx
@@ -99,7 +99,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
             const monthShort = date.toLocaleDateString(undefined, { month: 'short' }).toLowerCase();
             const holidays = getHolidaysForDate(date);
             return (
-              <div key={idx} className="bg-gray-50 p-3 sm:p-4 rounded-lg">
+              <div key={dateStr} className="bg-gray-50 p-3 sm:p-4 rounded-lg">
                 <div className="flex justify-between items-center mb-2 sm:mb-3">
                   <span className="font-medium flex flex-col items-start">
                     <span className="text-xs text-gray-500">{dayShort}</span>

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -619,7 +619,7 @@ const CreateMeetup = () => {
                   const dateStr = getLocalDateString(date);
                   const dateOpt = dateTimeOptions.find(opt => opt.date === dateStr);
                   return (
-                    <li key={idx}>
+                    <li key={dateStr}>
                       {date.toLocaleDateString()} ({(dateOpt?.times || []).join(', ')})
                     </li>
                   );


### PR DESCRIPTION
## Summary
- keep stable state for date selection lists

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build` *(fails: React/TypeScript compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_684183004c9c832dae2bfad4e123a029