### PR TITLE
Fix type errors after DateSelector refactor

### DIFF
--- a/src/components/meetups/DateSelector.tsx
+++ b/src/components/meetups/DateSelector.tsx
@@ -22,9 +22,11 @@ registerLocale('nl', nl);
  */
 export interface DateSelectorProps {
   selectedDates: Date[];
-  setSelectedDates: (dates: Date[]) => void;
+  setSelectedDates: React.Dispatch<React.SetStateAction<Date[]>>;
   dateTimeOptions: { date: string; times: string[] }[];
-  setDateTimeOptions: (opts: { date: string; times: string[] }[]) => void;
+  setDateTimeOptions: React.Dispatch<
+    React.SetStateAction<{ date: string; times: string[] }[]>
+  >;
   error?: string | null;
 }
 
@@ -49,7 +51,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const dayClassName = (date: Date) => {
     const dateStr = getLocalDateString(date);
     const exists = selectedDates.some(d => getLocalDateString(d) === dateStr);
-    return exists ? 'date-selected' : undefined;
+    return exists ? 'date-selected' : null;
   };
 
   // Add or remove a date
@@ -112,7 +114,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
       {selectedDates.length > 0 && (
         <div className="space-y-4">
           <h3 className="font-medium text-gray-700">{t('meetup.selectedDates', 'Your picked days')}</h3>
-          {selectedDates.map((date, idx) => {
+          {selectedDates.map(date => {
             const dateStr = getLocalDateString(date);
             const dateOpt = dateTimeOptions.find(opt => opt.date === dateStr);
             // New: compact date display

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -530,7 +530,15 @@ const CreateMeetup = () => {
           <p className="mb-3 sm:mb-4 text-gray-700 text-sm sm:text-base">{t('chooseTimes', 'Pick your preferred times for each date')}</p>
         <DateSelector
           selectedDates={formData.dates}
-          setSelectedDates={(dates: Date[]) => setFormData(prev => ({ ...prev, dates }))}
+          setSelectedDates={update =>
+            setFormData(prev => ({
+              ...prev,
+              dates:
+                typeof update === 'function'
+                  ? update(prev.dates)
+                  : update,
+            }))
+          }
           dateTimeOptions={dateTimeOptions}
           setDateTimeOptions={setDateTimeOptions}
           error={formError}
@@ -615,7 +623,7 @@ const CreateMeetup = () => {
             <div className="mb-2"><span className="font-medium">{t('meetup.city')}:</span> {formData.city}</div>
             <div className="mb-2"><span className="font-medium">{t('meetup.selectedDates')}:</span>
               <ul className="list-disc ml-6">
-                {formData.dates.map((date, idx) => {
+                {formData.dates.map(date => {
                   const dateStr = getLocalDateString(date);
                   const dateOpt = dateTimeOptions.find(opt => opt.date === dateStr);
                   return (


### PR DESCRIPTION
## Summary
- refine `DateSelectorProps` state setter types
- return `null` for non-highlighted days
- remove unused `idx` variables
- make `CreateMeetup` pass a SetStateAction to `DateSelector`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, hook deps, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684182586e94832d8b5245eed3a1495c