### PR TITLE
Fix invite link path

### DIFF
--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -32,7 +32,7 @@ const Invite = () => {
 
   useEffect(() => {
     if (token) {
-      setInviteLink(`${window.location.origin}/respond?token=${token}`);
+      setInviteLink(`${window.location.origin}/respond/${token}`);
       (async () => {
         setLoading(true);
         setError(null);

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
@@ -18,7 +18,7 @@ interface Cafe { name: string; address: string; image_url?: string; }
 
 const Respond = () => {
   const { t, i18n: _i18n } = useTranslation();
-  const location = useLocation();
+  const { token } = useParams();
   const [formData, setFormData] = useState({
     email: '',
     selectedTime: '',
@@ -94,8 +94,6 @@ const Respond = () => {
     let didCancel = false;
     const fetchData = async () => {
       try {
-        const params = new URLSearchParams(location.search);
-        const token = params.get('token');
         if (!token) {
           if (!didCancel) {
             setError(getRespondErrorMessage(t, 'respond.invalidInvitation', null));
@@ -168,7 +166,7 @@ const Respond = () => {
       didCancel = true;
       clearTimeout(timeout);
     };
-  }, [location.search, t]);
+  }, [token, t]);
 
   useEffect(() => {
     const viewport = document.querySelector('meta[name=viewport]');


### PR DESCRIPTION
## Summary
- build invite link using the `/respond/<token>` path
- update Respond page to read token from path parameters

## Testing
- `npm run build` *(fails: cannot find module '@supabase/supabase-js' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68418fe4d2d4832d9fe513272708df27