### PR TITLE
Restore signup and common translations

### DIFF
--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -18,6 +18,10 @@ export const en = {
       title: "Report an Issue"
     },
     testimonialsTitle: "What our users say",
+    testimonial1: "Anemi Meets saves me so much time! — Sophie, Rotterdam",
+    freeAccountInfo: "With a free account you can instantly plan Meetups and send invites!",
+    alreadyHaveAccount: "Already have an account? Login",
+    createAccount: "Create Account",
     error_invalid_email: "Please enter a valid email address",
     morning: "Morning",
     afternoon: "Afternoon",
@@ -179,7 +183,8 @@ export const en = {
     pastMeetups: "Past meetups",
   },
   toast: {
-    profileUpdated: "Profile updated!"
+    profileUpdated: "Profile updated!",
+    signupSuccess: "Account created! You're all set! ✨"
   },
   sessionExpiresSoon: "Your session will expire soon. Please log in again.",
 
@@ -205,6 +210,21 @@ export const en = {
     emailPlaceholder: "Your email address",
     passwordPlaceholder: "Your super secret password",
     loginButton: "Let me in!",
+  },
+  signup: {
+    title: "Sign up",
+    subtitle: "Create your free account to get started",
+    namePrompt: "We're glad you're here! What should we call you?",
+    namePlaceholder: "Your name",
+    emailPrompt: "Which email address can we use to connect you?",
+    emailPlaceholder: "Your email address",
+    passwordPrompt: "Which password do you want to use for this account?",
+    passwordPlaceholder: "Your password",
+    confirmPasswordPrompt: "Sorry, but we need to check if you typed your password correctly",
+    confirmPasswordPlaceholder: "Confirm your password",
+    overviewTitle: "Overview of your details",
+    submit: "Sign up",
+    steps: ["Name", "Email", "Password", "Overview"],
   },
   onboarding: {
     welcome: {

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -18,6 +18,10 @@ export const nl = {
       title: "Probleem melden"
     },
     testimonialsTitle: "Wat anderen zeggen",
+    testimonial1: "Anemi Meets bespaart me zoveel tijd! — Sophie, Rotterdam",
+    freeAccountInfo: "Met een gratis account kun je direct Meetups plannen en uitnodigingen versturen.",
+    alreadyHaveAccount: "Al een account? Inloggen",
+    createAccount: "Account aanmaken",
     error_invalid_email: "Voer een geldig e-mailadres in",
     morning: "Ochtend",
     afternoon: "Middag",
@@ -200,7 +204,8 @@ export const nl = {
     pastMeetups: "Afgelopen meetups",
   },
   toast: {
-    profileUpdated: "Profiel bijgewerkt!"
+    profileUpdated: "Profiel bijgewerkt!",
+    signupSuccess: "Account aangemaakt! Alles is geregeld! ✨"
   },
   sessionExpiresSoon: "Je sessie verloopt bijna. Log opnieuw in.",
 
@@ -226,6 +231,21 @@ export const nl = {
     emailPlaceholder: "Jouw e-mailadres",
     passwordPlaceholder: "Je geheime wachtwoord",
     loginButton: "Laat me binnen!",
+  },
+  signup: {
+    title: "Registreren",
+    subtitle: "Maak gratis je account aan om te beginnen",
+    namePrompt: "Leuk dat je er bent! Hoe mogen we je noemen?",
+    namePlaceholder: "Jouw naam",
+    emailPrompt: "Op welk e-mailadres kunnen we je bereiken?",
+    emailPlaceholder: "Jouw e-mailadres",
+    passwordPrompt: "Welk wachtwoord wil je gebruiken voor dit account?",
+    passwordPlaceholder: "Jouw wachtwoord",
+    confirmPasswordPrompt: "Sorry, maar we moeten even checken of je je wachtwoord goed hebt getypt",
+    confirmPasswordPlaceholder: "Bevestig je wachtwoord",
+    overviewTitle: "Overzicht van je gegevens",
+    submit: "Registreren",
+    steps: ["Naam", "E-mail", "Wachtwoord", "Overzicht"],
   },
   onboarding: {
     welcome: {


### PR DESCRIPTION
## Summary
- restore signup translations
- re-add general keys used by Signup page

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb9e66c4832db55fe6ffd9bc0293