### PR TITLE
Add Google OAuth login

### DIFF
--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -224,6 +224,7 @@ export const en = {
     emailPlaceholder: "Your email address",
     passwordPlaceholder: "Your super secret password",
     loginButton: "Let me in!",
+    googleButton: "Continue with Google",
   },
   signup: {
     title: "Sign up",

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -245,6 +245,7 @@ export const nl = {
     emailPlaceholder: "Jouw e-mailadres",
     passwordPlaceholder: "Je geheime wachtwoord",
     loginButton: "Laat me binnen!",
+    googleButton: "Inloggen met Google",
   },
   signup: {
     title: "Registreren",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -115,6 +115,11 @@ const Login = () => {
     setResetLoading(false);
   };
 
+  const handleGoogleLogin = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+    if (error) setError(normalizeAuthError(t, error));
+  };
+
   return (
     <main className="max-w-md mx-auto px-2 sm:px-0 py-6">
       <h1 className="mobile-heading text-primary-600 mb-6 text-center">
@@ -201,12 +206,20 @@ const Login = () => {
         >
           {t('login.loginButton')}
         </button>
-      </form>
+        </form>
 
-      <div className="text-center mt-4">
         <button
-          className="text-primary-600 underline hover:text-primary-800 text-sm"
-          onClick={() => navigate('/signup')}
+          type="button"
+          onClick={handleGoogleLogin}
+          className="btn-secondary w-full mt-4 py-3 px-6 text-lg rounded-lg flex justify-center"
+        >
+          {t('login.googleButton')}
+        </button>
+
+        <div className="text-center mt-4">
+          <button
+            className="text-primary-600 underline hover:text-primary-800 text-sm"
+            onClick={() => navigate('/signup')}
         >
           {t('login.noAccountCta')}
         </button>


### PR DESCRIPTION
## Summary
- allow logging in with Google OAuth on the Login page
- add translation for the new button in English and Dutch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68429d15c7f8832d82d9c66b2c7b970b