### PR TITLE
Include meetups where user is creator

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -61,7 +61,7 @@ const Dashboard = () => {
       const { data, error } = await supabase
         .from('invitations')
         .select('id, selected_date, selected_time, cafe_id, cafe_name, status, email_b')
-        .or(`invitee_id.eq.${session.user.id},email_b.eq."${session.user.email}"`);
+        .or(`invitee_id.eq.${session.user.id},email_b.eq."${session.user.email}",email_a.eq."${session.user.email}"`);
       if (error) {
         setError(t('dashboard.errorLoadingMeetups'));
       } else {

--- a/src/pages/Meetups.tsx
+++ b/src/pages/Meetups.tsx
@@ -110,7 +110,7 @@ const Meetups: React.FC = () => {
         const { data, error } = await supabase
           .from('invitations')
           .select('*')
-          .or(`invitee_id.eq.${session.user.id},email_b.eq.${session.user.email}`)
+          .or(`invitee_id.eq.${session.user.id},email_b.eq."${session.user.email}",email_a.eq."${session.user.email}"`)
           .order('selected_date', { ascending: true });
         if (error || !data) throw error || new Error('No data');
         setMeetups(data || []);


### PR DESCRIPTION
## Summary
- update Supabase invitation queries to also match creator's email
- ensure created meetups show up in dashboard and meetups list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842a9774a68832db5e8610cd0c1faa9