### PR TITLE
Add missing report issue translations

### DIFF
--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -15,7 +15,15 @@ export const en = {
     terms: "Terms & Conditions",
     contact: "Contact",
     reportIssue: {
-      title: "Report an Issue"
+      title: "Report an Issue",
+      descriptionLabel: "Describe the issue or idea",
+      descriptionPlaceholder: "Tell us what went wrong or share your idea...",
+      stepsLabel: "Steps to reproduce (optional)",
+      stepsPlaceholder: "List the steps so we can see the problem",
+      screenshotLabel: "Screenshot (optional)",
+      submit: "Submit report",
+      error: "Couldn't submit: {{error}}",
+      success: "Thanks! We've received your report."
     },
     testimonialsTitle: "What our users say",
     testimonial1: "Anemi Meets saves me so much time! — Sophie, Rotterdam",

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -15,7 +15,15 @@ export const nl = {
     terms: "Voorwaarden",
     contact: "Contact",
     reportIssue: {
-      title: "Probleem melden"
+      title: "Probleem melden",
+      descriptionLabel: "Beschrijf het probleem of idee",
+      descriptionPlaceholder: "Vertel wat er mis ging of wat beter kan...",
+      stepsLabel: "Stappen om te reproduceren (optioneel)",
+      stepsPlaceholder: "Noem de stappen zodat wij het kunnen nalopen",
+      screenshotLabel: "Screenshot (optioneel)",
+      submit: "Versturen",
+      error: "Oeps! Melding versturen mislukt: {{error}}",
+      success: "Bedankt! We hebben je melding ontvangen."
     },
     testimonialsTitle: "Wat anderen zeggen",
     testimonial1: "Anemi Meets bespaart me zoveel tijd! — Sophie, Rotterdam",


### PR DESCRIPTION
## Summary
- localize missing 'Report Issue' strings in English and Dutch

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842a979e554832db647d47edcd65ed7