### PR TITLE
Add contact form handler and translation

### DIFF
--- a/src/components/PolicyContactForm.tsx
+++ b/src/components/PolicyContactForm.tsx
@@ -13,7 +13,7 @@ const PolicyContactForm = () => {
     setLoading(true);
     setStatus('idle');
     try {
-      const res = await fetch('/api/contact', {
+      const res = await fetch('/functions/v1/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -32,6 +32,7 @@ export const en = {
     termsFull: "By using Anemi Meets you agree to use the service responsibly. Accounts that abuse the platform may be suspended.",
     rights: "All rights reserved.",
     lastUpdate: "Last updated:",
+    contactIntro: "Feel free to reach out using the form below.",
     contactName: "Your name",
     contactEmail: "Your email",
     contactMessage: "Your message",

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -32,6 +32,7 @@ export const nl = {
     termsFull: "Door Anemi Meets te gebruiken ga je akkoord met een verantwoord gebruik van het platform. Accounts die misbruik maken kunnen worden geblokkeerd.",
     rights: "Alle rechten voorbehouden.",
     lastUpdate: "Laatst bijgewerkt:",
+    contactIntro: "Stuur gerust een bericht via het onderstaande formulier.",
     contactName: "Jouw naam",
     contactEmail: "Jouw e-mailadres",
     contactMessage: "Jouw bericht",

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,7 +6,7 @@ const Contact = () => {
   return (
     <div className="max-w-2xl mx-auto py-12">
       <h1 className="text-3xl font-bold text-primary-600 mb-6">{t('contact')}</h1>
-      <p className="mb-4">{t('contactMessage')}</p>
+      <p className="mb-4">{t('contactIntro')}</p>
       <PolicyContactForm />
     </div>
   );

--- a/supabase/functions/contact/index.ts
+++ b/supabase/functions/contact/index.ts
@@ -1,0 +1,29 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+    });
+  }
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400 });
+  }
+
+  const { name, email, message } = body;
+  if (!name || !email || !message) {
+    return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      received: { name, email, message, receivedAt: new Date().toISOString() },
+    }),
+    { status: 200 },
+  );
+});


### PR DESCRIPTION
## Summary
- add `contactIntro` translation to English and Dutch locales
- show `contactIntro` text on the contact page
- post contact form data to new `/functions/v1/contact` endpoint
- implement edge function at `supabase/functions/contact`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a9788458832d9c4194149fd38061