### PR TITLE
Update README with function deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ src/
 - `npm run lint` - Run ESLint
 - `npm run preview` - Preview production build
 
+## Deploying Supabase Functions
+
+Deploy the reminder function with:
+
+```bash
+supabase functions deploy send-meeting-reminders --project-ref <your-project-id> --no-verify-jwt
+```
+
+Configure the schedule for this function in `supabase/config.toml`. See the [Supabase docs](https://supabase.com/docs/guides/functions/schedule-functions) for details.
+
 ## Contributing
 
 1. Fork the repository

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -285,6 +285,11 @@ inspector_port = 8083
 # The Deno major version to use.
 deno_version = 1
 
+# Cron triggers for Edge Functions
+# [functions.schedules]
+# send-meeting-reminders = "0 8 * * *"
+# See https://supabase.com/docs/guides/functions/schedule-functions
+
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 


### PR DESCRIPTION
## Summary
- document how to deploy the reminder function via the Supabase CLI
- note that the schedule is configured in `supabase/config.toml`
- add a commented scheduling example referencing the docs

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68433f07e6a8832db599b3c10d46ce0d