### PR TITLE
Add Playwright e2e test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ src/
 - `npm run build` - Build for production
 - `npm run lint` - Run ESLint
 - `npm run preview` - Preview production build
+- `npm run test:e2e` - Run Playwright end-to-end tests
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"supabase/**/*.ts\" \"e2e/**/*.ts\" --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright install --with-deps && playwright test"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.19",


### PR DESCRIPTION
## Summary
- add `test:e2e` Playwright script to `package.json`
- document running E2E tests in the README

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68433f094e20832d99bd659edfda739c