### PR TITLE
Add reminder preferences

### DIFF
--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -177,6 +177,8 @@ export const en = {
     ageEditHint: "How young do you feel? Type it in!",
     wantsUpdates: "Send me fun updates!",
     wantsUpdatesCheckbox: "Yeah, I want to receive updates!",
+    wantsReminders: "Send me meetup reminders",
+    wantsRemindersCheckbox: "Yes, remind me before a meetup!",
     isPrivate: "Keep my profile private",
     isPrivateCheckbox: "Yeah, I want to keep my profile private!",
     dangerZone: "Danger Zone",

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -198,6 +198,8 @@ export const nl = {
     ageEditHint: "Hoe jong voel je je? Typ het in!",
     wantsUpdates: "Stuur me leuke updates!",
     wantsUpdatesCheckbox: "Ja, ik wil updates ontvangen!",
+    wantsReminders: "Stuur me herinneringen voor meetups",
+    wantsRemindersCheckbox: "Ja, herinner me per e-mail!",
     isPrivate: "Houd mijn profiel privé",
     isPrivateCheckbox: "Ja, ik wil mijn profiel privé houden!",
     dangerZone: "Gevaarzone",

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -17,6 +17,7 @@ interface Profile {
   gender?: string;
   age?: number;
   wants_updates: boolean;
+  wants_reminders?: boolean;
   is_private: boolean;
 }
 
@@ -41,6 +42,7 @@ const Account = () => {
   const [email, setEmail] = useState('');
   const [pwForm, setPwForm] = useState({ current: '', new: '', confirm: '' });
   const [wantsUpdates, setWantsUpdates] = useState(false);
+  const [wantsReminders, setWantsReminders] = useState(true);
   const [isPrivate, setIsPrivate] = useState(false);
   const [prefsSaving, setPrefsSaving] = useState(false);
   const [showPwForm, setShowPwForm] = useState(false);
@@ -80,6 +82,7 @@ const Account = () => {
         if (testProfiles.emoji) setSelectedEmoji(testProfiles.emoji);
         if (testProfiles.age !== undefined && testProfiles.age !== null) setAge(testProfiles.age);
         setWantsUpdates(!!testProfiles.wants_updates);
+        setWantsReminders(testProfiles.wants_reminders !== false);
         setIsPrivate(!!testProfiles.is_private);
       } else {
         setUser(null);
@@ -143,7 +146,11 @@ const Account = () => {
   const handlePrefsSave = async () => {
     if (!user || !user.id) return;
     setPrefsSaving(true);
-    const { error } = await supabase.from('profiles').update({ wants_updates: wantsUpdates, is_private: isPrivate }).eq('id', user.id);
+    const { error } = await supabase.from('profiles').update({
+      wants_updates: wantsUpdates,
+      wants_reminders: wantsReminders,
+      is_private: isPrivate
+    }).eq('id', user.id);
     if (error) {
       console.error('Fout bij opslaan voorkeuren:', error);
     } else {
@@ -234,6 +241,19 @@ const Account = () => {
                       onChange={(e) => setWantsUpdates(e.target.checked)}
                     />
                     {t('account.wantsUpdatesCheckbox', 'Yeah, I want to receive updates!')}
+                  </label>
+                </div>
+              </div>
+              <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+                <label className="w-full sm:w-32 font-semibold">{t('account.wantsReminders')}</label>
+                <div className="flex-1 flex flex-col gap-2">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={wantsReminders}
+                      onChange={(e) => setWantsReminders(e.target.checked)}
+                    />
+                    {t('account.wantsRemindersCheckbox', 'Yes, remind me before a meetup!')}
                   </label>
                 </div>
               </div>

--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -116,6 +116,24 @@ Deno.serve(async (req) => {
       <b>${isEnglish ? "Time" : "Tijd"}:</b> ${readableTime} on ${selected_date}</p>
       <p><a href="${gcalUrl}" target="_blank">➕ ${isEnglish ? "Add to Google Calendar" : "Voeg toe aan Google Calendar"}</a></p>`;
 
+    const recipients: string[] = [];
+    const { data: profileA } = await supabase
+      .from("profiles")
+      .select("wants_reminders")
+      .eq("email", email_a)
+      .maybeSingle();
+    if (!profileA || profileA.wants_reminders !== false) {
+      recipients.push(email_a);
+    }
+    const { data: profileB } = await supabase
+      .from("profiles")
+      .select("wants_reminders")
+      .eq("email", email_b)
+      .maybeSingle();
+    if (!profileB || profileB.wants_reminders !== false) {
+      recipients.push(email_b);
+    }
+
     const emailRes = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
@@ -124,7 +142,7 @@ Deno.serve(async (req) => {
       },
       body: JSON.stringify({
         from: "noreply@anemimeets.com",
-        to: [email_a, email_b],
+        to: recipients,
         subject,
         html,
         attachments: [{

--- a/supabase/migrations/20240320_add_wants_reminders.sql
+++ b/supabase/migrations/20240320_add_wants_reminders.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN wants_reminders boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary
- support wants_reminders flag in db
- add reminder preference toggle in account page
- respect flag when emailing confirmations
- migrate new wants_reminders column

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68433f0660f8832d86f048a1e3d82a0e