### PR TITLE
Add simple success screen

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -9,6 +9,7 @@ import CreateMeetup from './pages/CreateMeetup';
 import Invite from './pages/Invite';
 import Respond from './pages/Respond';
 import Confirmed from './pages/Confirmed';
+import Success from './pages/Success';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import CookiePolicy from './pages/CookiePolicy';
 import Terms from './pages/Terms';
@@ -33,6 +34,7 @@ const AppRoutes = () => {
           <Route path="/invite/:token" element={<Invite />} />
           <Route path="/respond/:token" element={<Respond />} />
           <Route path="/confirmed" element={<Confirmed />} />
+          <Route path="/success" element={<Success />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />
           <Route path="/cookies" element={<CookiePolicy />} />
           <Route path="/terms" element={<Terms />} />

--- a/src/components/StepperForm.tsx
+++ b/src/components/StepperForm.tsx
@@ -34,11 +34,8 @@ Uitleg in code-comments zodat een beginner snapt wat er gebeurt.
 #endregion */ 
 
 import React, { useState } from 'react';
-import { Player } from '@lottiefiles/react-lottie-player';
 import { useSwipeable } from 'react-swipeable';
 import { useTranslation } from 'react-i18next';
-// Confetti animatie-bestand (bijv. public/confetti.json)
-// Download een confetti lottie van lottiefiles.com en plaats in public/confetti.json
 
 // --- Dummy cafés ---
 const cafes = [
@@ -217,34 +214,23 @@ export default function StepperForm({ locale = 'nl' }: { locale?: 'nl' | 'en' })
     }
   }
 
-  // --- Bevestigingsscherm met confetti ---
+  // --- Bevestigingsscherm ---
   if (success) {
     return (
       <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
         <div className="card max-w-md w-full text-center">
           <div className="mb-6">
-            <Player
-              autoplay
-              loop
-              src="/confetti.json"
-              style={{ width: '100%', height: '200px' }}
-            />
+            <img src="/coffee.svg" alt="Success" className="mx-auto w-24 h-24" />
           </div>
           <h2 className="mobile-heading text-primary-700 mb-4">{t('success.title')}</h2>
           <p className="mobile-text text-gray-600 mb-8">{t('success.message')}</p>
           <div className="space-y-4">
-            <button
-              onClick={() => window.location.href = '/'}
-              className="btn-primary w-full"
-            >
+            <button onClick={() => (window.location.href = '/')} className="btn-primary w-full">
               {t('success.button')}
             </button>
             <div className="pt-4 border-t border-gray-200">
               <p className="mobile-text text-gray-600 mb-4">{t('cta')}</p>
-              <button
-                onClick={() => window.location.href = '/register'}
-                className="btn-secondary w-full"
-              >
+              <button onClick={() => (window.location.href = '/register')} className="btn-secondary w-full">
                 {t('register')}
               </button>
             </div>

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -1,46 +1,19 @@
-import { useTranslation } from "react-i18next";
-import { useMemo } from "react";
+import { Link } from 'react-router-dom';
 
-export default function Success() {
-  const { t } = useTranslation();
-
-  // Voeg meerdere gifs toe
-  const gifs = [
-    "/assets/confetti.gif",
-    "/assets/party.gif",
-    "/assets/fireworks.gif",
-    "/assets/celebrate.gif"
-  ];
-  // Kies random één gif bij laden
-  const selectedGif = useMemo(() => gifs[Math.floor(Math.random() * gifs.length)], []);
-
+const Success = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-screen px-4 text-center bg-[#fdfcfa]">
-      {/* Willekeurige confetti/feest gif */}
-      <img
-        src={selectedGif}
-        alt="Confetti"
-        className="w-32 h-32 mb-6 animate-bounce"
-      />
-      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
-        🎉 {t("success.title")}
-      </h1>
-      <p className="text-[#444] mt-2 mb-6">{t("success.description")}</p>
-      <a
-        href="/"
-        className="bg-[#aadfd4] text-[#1a1a1a] px-6 py-3 rounded-2xl font-medium hover:bg-[#98cfc4] transition"
+    <div className="flex flex-col items-center justify-center h-screen text-center p-4 bg-white">
+      <img src="/coffee.svg" alt="Success" className="w-24 h-24 mb-6" />
+      <h1 className="text-2xl font-semibold text-primary-700 mb-2">Success!</h1>
+      <p className="text-gray-700 mb-4">Your action was completed.</p>
+      <Link
+        to="/"
+        className="bg-orange-400 text-white px-6 py-3 rounded-full hover:bg-orange-500 transition"
       >
-        {t("success.button")}
-      </a>
-      <div className="mt-8 bg-white/80 rounded-xl p-6 shadow text-center flex flex-col items-center">
-        <p className="text-lg text-[#1a1a1a] mb-3">Wil jij ook terug naar echte connecties?<br />Registreer dan nu!</p>
-        <a
-          href="/signup"
-          className="bg-[#f7b267] text-[#1a1a1a] px-6 py-3 rounded-2xl font-medium hover:bg-[#f4a259] transition mt-2"
-        >
-          Account aanmaken
-        </a>
-      </div>
+        Back to home
+      </Link>
     </div>
   );
-} 
+};
+
+export default Success;


### PR DESCRIPTION
## Summary
- implement a basic success page using existing `coffee.svg`
- expose the success page in `AppRoutes`
- remove lottie confetti from `StepperForm`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684361c47130832dadb9e82799ffd0ab