### PR TITLE
Add calendar download and notification opt‑in

### DIFF
--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -182,6 +182,8 @@ export const en = {
     wantsUpdatesCheckbox: "Yeah, I want to receive updates!",
     wantsReminders: "Send me meetup reminders",
     wantsRemindersCheckbox: "Yes, remind me before a meetup!",
+    wantsNotifications: "Browser notifications",
+    wantsNotificationsCheckbox: "Yes, allow browser notifications!",
     isPrivate: "Keep my profile private",
     isPrivateCheckbox: "Yeah, I want to keep my profile private!",
     dangerZone: "Danger Zone",

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -200,6 +200,8 @@ export const nl = {
     wantsUpdatesCheckbox: "Ja, ik wil updates ontvangen!",
     wantsReminders: "Stuur me herinneringen voor meetups",
     wantsRemindersCheckbox: "Ja, herinner me per e-mail!",
+    wantsNotifications: "Browser notificaties",
+    wantsNotificationsCheckbox: "Ja, stuur meldingen in mijn browser!",
     isPrivate: "Houd mijn profiel privé",
     isPrivateCheckbox: "Ja, ik wil mijn profiel privé houden!",
     dangerZone: "Gevaarzone",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ interface Profile {
 
 const Dashboard = () => {
   const { t, i18n } = useTranslation();
+  const DASHBOARD_CACHE_KEY = 'dashboard_cache_v1';
   const [meetups, setMeetups] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +44,20 @@ const Dashboard = () => {
     const fetchData = async () => {
       setLoading(true);
       setError(null);
+      const cached = localStorage.getItem(DASHBOARD_CACHE_KEY);
+      if (!navigator.onLine && cached) {
+        try {
+          const cache = JSON.parse(cached);
+          setProfile(cache.profile || null);
+          setFriends(cache.friends || []);
+          setPendingFriends(cache.pendingFriends || []);
+          setMeetups(cache.meetups || []);
+          setLoading(false);
+          return;
+        } catch (err) {
+          console.error(err);
+        }
+      }
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.user) {
         navigate('/login');
@@ -97,9 +112,31 @@ const Dashboard = () => {
         .select('id, selected_date, selected_time, cafe_id, cafe_name, status, email_b')
         .or(`invitee_id.eq.${session.user.id},email_b.eq."${session.user.email}",email_a.eq."${session.user.email}"`);
       if (error) {
+        if (cached) {
+          try {
+            const cache = JSON.parse(cached);
+            setProfile(cache.profile || null);
+            setFriends(cache.friends || []);
+            setPendingFriends(cache.pendingFriends || []);
+            setMeetups(cache.meetups || []);
+            setLoading(false);
+            return;
+          } catch (err) {
+            console.error(err);
+          }
+        }
         setError(t('dashboard.errorLoadingMeetups'));
       } else {
         setMeetups((data || []) as Invitation[]);
+        localStorage.setItem(
+          DASHBOARD_CACHE_KEY,
+          JSON.stringify({
+            profile: profileData,
+            friends: friendsList,
+            pendingFriends: pendingList,
+            meetups: data || []
+          })
+        );
       }
       setLoading(false);
     };

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -36,6 +36,16 @@ const Invite = () => {
       (async () => {
         setLoading(true);
         setError(null);
+        const cached = localStorage.getItem(`friend_invite_${token}`);
+        if (!navigator.onLine && cached) {
+          try {
+            setInvitation(JSON.parse(cached));
+            setLoading(false);
+            return;
+          } catch (err) {
+            console.error(err);
+          }
+        }
         try {
           const { data: inviteData, error: inviteError } = await supabase
             .from('invitations')
@@ -59,6 +69,8 @@ const Invite = () => {
               }
             }
             setInvitation(inviteData as InvitationWithCafe);
+            localStorage.setItem(`friend_invite_${token}`,
+              JSON.stringify(inviteData));
           }
         } catch (err) {
           setError(t('invite.errorNotFound', 'This invitation link is invalid or expired.'));

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -15,6 +15,13 @@ interface Invitation {
   date_time_options?: { date: string; times: string[] }[];
 }
 interface Cafe { name: string; address: string; image_url?: string; }
+interface ConfirmationInfo {
+  cafe_name: string;
+  cafe_address: string;
+  selected_date: string;
+  selected_time: string;
+  ics_base64?: string;
+}
 
 const Respond = () => {
   const { t, i18n: _i18n } = useTranslation();
@@ -31,7 +38,7 @@ const Respond = () => {
   const [errorMsg, setErrorMsg] = useState<string>("");
   const [invitation, setInvitation] = useState<Invitation | null>(null);
   const [submitted, setSubmitted] = useState(false);
-  const [confirmationInfo, setConfirmationInfo] = useState<any>(null);
+  const [confirmationInfo, setConfirmationInfo] = useState<ConfirmationInfo | null>(null);
 
   const UPDATES_EMAIL_KEY = 'anemi-updates-email';
 
@@ -247,7 +254,8 @@ const Respond = () => {
           cafe_name: data.cafe_name,
           cafe_address: data.cafe_address,
           selected_date: data.selected_date,
-          selected_time: data.selected_time
+          selected_time: data.selected_time,
+          ics_base64: data.ics_base64
         });
       }
     } catch (err) {
@@ -277,6 +285,15 @@ const Respond = () => {
               <div className="text-gray-600 mb-1">{_i18n.language === 'nl' ? 'Adres' : 'Address'}: {confirmationInfo.cafe_address}</div>
               <div className="text-gray-600 mb-1">{_i18n.language === 'nl' ? 'Datum' : 'Date'}: {confirmationInfo.selected_date}</div>
               <div className="text-gray-600">{_i18n.language === 'nl' ? 'Tijd' : 'Time'}: {confirmationInfo.selected_time}</div>
+              {confirmationInfo.ics_base64 && (
+                <a
+                  href={`data:text/calendar;base64,${confirmationInfo.ics_base64}`}
+                  download="meeting.ics"
+                  className="btn-secondary mt-4 inline-block"
+                >
+                  {_i18n.language === 'nl' ? 'Download agenda-item' : 'Download calendar file'}
+                </a>
+              )}
             </div>
           )}
           <div className="w-full flex flex-col items-center mt-2">

--- a/src/utils/browserNotifications.ts
+++ b/src/utils/browserNotifications.ts
@@ -1,0 +1,7 @@
+export async function requestBrowserNotificationPermission(): Promise<NotificationPermission> {
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return 'denied';
+  }
+  const result = await Notification.requestPermission();
+  return result;
+}

--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -121,6 +121,7 @@ Deno.serve(async (req) => {
     const dtStamp = new Date().toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
 
     const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtStamp}\nSUMMARY:Koffie Meetup\nDTSTART:${datePart}${dtStart}\nDTEND:${datePart}${dtEnd}\nDESCRIPTION:Jullie koffie-afspraak!\nLOCATION:${cafe.name} ${cafe.address}\nEND:VEVENT\nEND:VCALENDAR`;
+    const icsBase64 = encodeBase64(ics);
 
     const cafeImageUrl = cafe.image_url || `https://source.unsplash.com/600x300/?coffee,${encodeURIComponent(cafe.name)}`;
     const gcalUrl = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent("Koffie Meetup via Anemi")}&dates=${datePart}${dtStart}/${datePart}${dtEnd}&location=${encodeURIComponent(`${cafe.name} ${cafe.address}`)}`;
@@ -157,7 +158,7 @@ Deno.serve(async (req) => {
           html,
           attachments: [{
             filename: "meeting.ics",
-            content: encodeBase64(ics),
+            content: icsBase64,
             type: "text/calendar"
           }]
         })
@@ -172,7 +173,8 @@ Deno.serve(async (req) => {
       cafe_address: cafe.address,
       invitation_token: token,
       selected_date,
-      selected_time
+      selected_time,
+      ics_base64: icsBase64
     }), {
       status: 200,
       headers: { "Access-Control-Allow-Origin": "*" }

--- a/supabase/migrations/20240517_add_wants_notifications.sql
+++ b/supabase/migrations/20240517_add_wants_notifications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN wants_notifications boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- allow `.ics` file download link from `send-meeting-confirmation`
- add browser notification opt‑in and migration
- support caching for dashboard and invite pages
- add helper for requesting browser notifications

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: playwright download needs network)*

------
https://chatgpt.com/codex/tasks/task_e_684361c9c054832d8d2942a989e5b142