### PR TITLE
Guard console.log in Respond page

### DIFF
--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -248,8 +248,10 @@ const Respond = () => {
         console.error("Supabase error:", data.error || data);
       } else {
         setSubmitted(true);
-        // Log en bewaar de response data
-        console.log('Meeting bevestigd:', data);
+        // Log en bewaar de response data (development only)
+        if (import.meta.env.DEV) {
+          console.log('Meeting bevestigd:', data);
+        }
         setConfirmationInfo({
           cafe_name: data.cafe_name,
           cafe_address: data.cafe_address,


### PR DESCRIPTION
## Summary
- wrap meeting confirmation logging in a dev check

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684369517228832db4be9f9787c0c859