### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm run test:e2e


### PR DESCRIPTION
## Summary
- add CI workflow running npm ci, lint, build and e2e tests

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run test:e2e` *(fails: Cannot navigate to invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef148c64832d9c494dc7ca56a3ef