### PR TITLE
Use generated Supabase types

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import type { Database } from '../types/supabase';
 import { useTranslation } from 'react-i18next';
 import SkeletonLoader from '../components/SkeletonLoader';
 import React from 'react';
@@ -10,18 +11,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import { requestBrowserNotificationPermission } from '../utils/browserNotifications';
 
 // TypeScript interfaces voor typeveiligheid
-interface Profile {
-  id: string;
-  full_name: string;
-  email: string;
-  emoji?: string;
-  gender?: string;
-  age?: number;
-  wants_updates: boolean;
-  wants_reminders?: boolean;
-  wants_notifications?: boolean;
-  is_private: boolean;
-}
+type Profile = Database['public']['Tables']['profiles']['Row'];
 
 interface Invitation {
   id: string;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import type { Database } from '../types/supabase';
 import { useTranslation } from 'react-i18next';
 import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
@@ -16,13 +17,7 @@ interface Invitation {
   email_b?: string;
 }
 
-interface Profile {
-  id: string;
-  full_name: string;
-  emoji?: string;
-  last_seen?: string;
-  email?: string;
-}
+type Profile = Database['public']['Tables']['profiles']['Row'];
 
 const Dashboard = () => {
   const { t, i18n } = useTranslation();

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Database } from './types/supabase';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
@@ -8,4 +9,4 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase configuration. Please check environment variables.');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- import generated database types in the Supabase client
- use row type for profiles in dashboard and account pages

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npx supabase gen types typescript --local > src/types/supabase.ts` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef115c74832da146ae79402c2d90