### PR TITLE
Improve typing and enable no-explicit-any

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -24,7 +24,7 @@ module.exports = [
     ],
     rules: {
       'react-refresh/only-export-components': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': 'off',
       'no-case-declarations': 'off',
       'no-useless-escape': 'off',

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { withTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 interface ErrorBoundaryProps {
-  t: any;
+  t: TFunction;
   fallback?: React.ReactNode;
   children: React.ReactNode;
 }

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -5,7 +5,10 @@ import { NavigationContext } from '../context/NavigationContext';
 import ErrorBoundary from './ErrorBoundary';
 import { Transition } from '@headlessui/react';
 
-const NavigationBar = ({ profileEmoji }: { profileEmoji?: string }) => {
+export interface NavigationBarProps {
+  profileEmoji?: string;
+}
+const NavigationBar: React.FC<NavigationBarProps> = ({ profileEmoji }) => {
   const { t, i18n } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const { activePath, isAuthenticated } = useContext(NavigationContext);
@@ -248,7 +251,7 @@ const NavigationBar = ({ profileEmoji }: { profileEmoji?: string }) => {
   );
 };
 
-const NavigationBarWithBoundary = (props: any) => (
+const NavigationBarWithBoundary: React.FC<NavigationBarProps> = (props) => (
   <ErrorBoundary>
     <NavigationBar {...props} />
   </ErrorBoundary>

--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -64,8 +64,9 @@ const ReportIssueModal: React.FC<Props> = ({ open, onClose }) => {
       setDescription('');
       setSteps('');
       setScreenshot(null);
-    } catch (err: any) {
-      setError(err.message || 'Onbekende fout');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Onbekende fout';
+      setError(message);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import { useTranslation } from 'react-i18next';
+import type { TFunction, i18n as I18n } from 'i18next';
 import SkeletonLoader from '../components/SkeletonLoader';
 import React from 'react';
 import FormStatus from '../components/FormStatus';
@@ -108,9 +109,10 @@ const Account = () => {
         } else {
           setMyMeetups((meetups || []) as Invitation[]);
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error('Onverwachte fout bij ophalen meetups:', err);
-        setMeetupsError(t('account.errorLoadingMeetupsDetails', { details: err.message || err.toString() }));
+        const details = err instanceof Error ? err.message : String(err);
+        setMeetupsError(t('account.errorLoadingMeetupsDetails', { details }));
         setMyMeetups([]);
       }
       setMeetupsLoading(false);
@@ -440,7 +442,14 @@ const Account = () => {
   );
 };
 
-const MeetupListItem = React.memo(function MeetupListItem({ m, t, statusLabels, i18n }: { m: Invitation, t: any, statusLabels: Record<string, string>, i18n: any }) {
+interface MeetupListItemProps {
+  m: Invitation;
+  t: TFunction;
+  statusLabels: Record<string, string>;
+  i18n: I18n;
+}
+
+const MeetupListItem = React.memo(function MeetupListItem({ m, t, statusLabels, i18n }: MeetupListItemProps) {
   return (
     <li key={m.id} className="bg-white rounded-xl shadow p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between border border-primary-100 mb-2 transition hover:shadow-md">
       <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 w-full">
@@ -457,7 +466,13 @@ const MeetupListItem = React.memo(function MeetupListItem({ m, t, statusLabels, 
   );
 });
 
-const MeetupsList = ({ meetups, t, i18n }: { meetups: Invitation[], t: any, i18n: any }) => {
+interface MeetupsListProps {
+  meetups: Invitation[];
+  t: TFunction;
+  i18n: I18n;
+}
+
+const MeetupsList = ({ meetups, t, i18n }: MeetupsListProps) => {
   const statusLabels: Record<string, string> = {
     confirmed: t('account.status.confirmed', 'Confirmed'),
     pending: t('account.status.pending', 'Pending'),

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -5,9 +5,14 @@ import { supabase } from '../supabaseClient';
 import "react-datepicker/dist/react-datepicker.css";
 import DateSelector from '../components/meetups/DateSelector';
 import { useNavigate } from 'react-router-dom';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 interface City { id: string; name: string; }
 interface Cafe { id: string; name: string; address: string; description?: string; image_url?: string; }
+
+interface User {
+  email: string;
+}
 
 const getLastCity = () => {
   if (typeof window !== 'undefined') {
@@ -18,7 +23,7 @@ const getLastCity = () => {
 
 const QUEUE_KEY = 'meetups_queue_v1';
 
-async function flushMeetupQueue(supabase: any, onSuccess: () => void) {
+async function flushMeetupQueue(supabase: SupabaseClient, onSuccess: () => void) {
   const queue = JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]');
   if (!queue.length) return;
   const newQueue = [];
@@ -53,7 +58,7 @@ const CreateMeetup = () => {
   const [shuffleCooldown, setShuffleCooldown] = useState(false);
   const shuffleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [step, setStep] = useState(1);
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isLoadingCities, setIsLoadingCities] = useState(true);
   const [cityError, setCityError] = useState<string | null>(null);
@@ -220,7 +225,18 @@ const CreateMeetup = () => {
       console.log('Generated token:', token);
     }
 
-    const payload: any = {
+    interface InvitePayload {
+      token: string;
+      invitee_name: string;
+      status: string;
+      selected_date: string;
+      selected_time: string;
+      cafe_id: string;
+      date_time_options: { date: string; times: string[] }[];
+      email_a?: string;
+    }
+
+    const payload: InvitePayload = {
       token,
       invitee_name: formData.name,
       status: "pending",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import LoadingIndicator from '../components/LoadingIndicator';
@@ -42,7 +43,8 @@ const Login = () => {
     }
   }, []);
 
-  function normalizeAuthError(t: any, error: any) {
+  interface AuthError { code?: string; message?: string }
+  function normalizeAuthError(t: TFunction, error: AuthError) {
     let msg = t('error_generic');
     const code = error.code || '';
     switch (code) {

--- a/src/pages/Meetups.tsx
+++ b/src/pages/Meetups.tsx
@@ -15,11 +15,24 @@ interface Meetup {
   status?: string;
   email_b?: string;
   invitee_id?: string;
+  token?: string;
 }
 
 const LOCAL_CACHE_KEY = 'meetups_cache_v1';
 
-const MeetupListItem = React.memo(function MeetupListItem({ meetup, onView, onJoin, t, i18n, joining, joinLoadingId }: { meetup: Meetup, onView: (id: string) => void, onJoin: (id: string) => void, t: any, i18n: any, joining: boolean, joinLoadingId: string | null }) {
+import type { TFunction, i18n as I18n } from 'i18next';
+
+interface MeetupListItemProps {
+  meetup: Meetup;
+  onView: (id: string) => void;
+  onJoin: (id: string) => void;
+  t: TFunction;
+  i18n: I18n;
+  joining: boolean;
+  joinLoadingId: string | null;
+}
+
+const MeetupListItem = React.memo(function MeetupListItem({ meetup, onView, onJoin, t, i18n, joining, joinLoadingId }: MeetupListItemProps) {
   return (
     <div
       className="card hover:shadow-lg transition-shadow duration-300"
@@ -127,7 +140,8 @@ const Meetups: React.FC = () => {
         } else {
           setMeetups([]);
         }
-        setError(t('meetups:errorLoading', { details: typeof err === 'object' && err && 'message' in err ? (err as any).message : String(err) }));
+        const details = err instanceof Error ? err.message : String(err);
+        setError(t('meetups:errorLoading', { details }));
         setLoading(false);
       }
     };
@@ -158,7 +172,7 @@ const Meetups: React.FC = () => {
       if (!meetup) throw new Error('Meetup not found');
 
       const body = {
-        token: (meetup as any).token,
+        token: meetup.token,
         email_b: sessionData.session.user.email,
         selected_date: meetup.selected_date,
         selected_time: meetup.selected_time,

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../supabaseClient';
 import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
 import FormStatus from '../components/FormStatus';
+import type { TFunction, i18n as I18n } from 'i18next';
 
 // TypeScript interfaces voor typeveiligheid
 interface Invitation {
@@ -42,7 +43,8 @@ const Respond = () => {
 
   const UPDATES_EMAIL_KEY = 'anemi-updates-email';
 
-  function getRespondErrorMessage(t: any, key: string, error: any) {
+  interface GenericError { message?: string }
+  function getRespondErrorMessage(t: TFunction, key: string, error: GenericError | null) {
     const translated = t(key);
     if (translated === key) {
       return `Error: ${error?.message || 'Unknown error'}`;
@@ -50,7 +52,7 @@ const Respond = () => {
     return translated;
   }
 
-  function mapRespondError(t: any, data: any, _i18n: any) {
+  function mapRespondError(t: TFunction, data: { error?: string; error_code?: string }, _i18n: I18n) {
     let msg = getRespondErrorMessage(t, 'respond.genericError', data.error);
     if (data.error && typeof data.error === 'string') {
       const err = data.error.toLowerCase();
@@ -225,7 +227,16 @@ const Respond = () => {
       localStorage.removeItem(UPDATES_EMAIL_KEY);
     }
     try {
-      const body: any = {
+      interface ConfirmRequestBody {
+        token: string;
+        email: string;
+        email_b: string;
+        selected_date: string;
+        selected_time: string;
+        cafe_id: string;
+      }
+
+      const body: ConfirmRequestBody = {
         token: invitation.token,
         email: formData.email,
         email_b: formData.email,

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -59,7 +59,8 @@ const Signup = () => {
     setErrors(errs => ({ ...errs, [field]: undefined }));
   };
 
-  const getErrorMessage = (key: string, error: any) => {
+  interface SignupError { message?: string }
+  const getErrorMessage = (key: string, error: SignupError | null) => {
     const translated = t(key);
     if (translated === key) {
       return `Error: ${error?.message || 'Unknown error'}`;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -221,7 +221,7 @@ export interface FilterOptions {
   sortOrder?: 'asc' | 'desc';
   page?: number;
   pageSize?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -5,8 +5,8 @@ export interface ApiError {
 }
 
 export const handleApiError = (error: unknown): ApiError => {
-  if (typeof error === 'object' && error !== null && (error as any).isAxiosError === true) {
-    const axiosError = error as any;
+  if (typeof error === 'object' && error !== null && (error as AxiosError).isAxiosError === true) {
+    const axiosError = error as AxiosError;
     const status = axiosError.response?.status;
     const data = axiosError.response?.data;
 
@@ -91,3 +91,4 @@ export const handleApiError = (error: unknown): ApiError => {
     details: error,
   };
 };
+import type { AxiosError } from 'axios';

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -175,7 +175,7 @@ export function isPaginatedResponse<T extends TableName>(
 /**
  * Type guard for filter options
  */
-export function isFilterOptions(value: unknown): value is Record<string, any> {
+export function isFilterOptions(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 

--- a/supabase/functions/contact/index.ts
+++ b/supabase/functions/contact/index.ts
@@ -7,7 +7,8 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  let body: any;
+  interface ContactBody { name: string; email: string; message: string }
+  let body: ContactBody;
   try {
     body = await req.json();
   } catch {

--- a/supabase/functions/report-issue/index.ts
+++ b/supabase/functions/report-issue/index.ts
@@ -5,7 +5,13 @@ Deno.serve(async (req: Request) => {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
   }
 
-  let body: any;
+  interface ReportBody {
+    description: string;
+    steps?: string;
+    screenshot?: string | null;
+    context?: unknown;
+  }
+  let body: ReportBody;
   try {
     body = await req.json();
   } catch (e) {


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-explicit-any` in ESLint
- define props and parameter interfaces across the codebase
- replace `any` usages with explicit types
- update Supabase functions with typed request bodies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843ef0faac4832d9432c00fb9abe6fe