### PR TITLE
Standardize casing across database and code

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -12,15 +12,15 @@ import { requestBrowserNotificationPermission } from '../utils/browserNotificati
 // TypeScript interfaces voor typeveiligheid
 interface Profile {
   id: string;
-  full_name: string;
+  fullName: string;
   email: string;
   emoji?: string;
   gender?: string;
   age?: number;
-  wants_updates: boolean;
-  wants_reminders?: boolean;
-  wants_notifications?: boolean;
-  is_private: boolean;
+  wantsUpdates: boolean;
+  wantsReminders?: boolean;
+  wantsNotifications?: boolean;
+  isPrivate: boolean;
 }
 
 interface Invitation {
@@ -84,10 +84,10 @@ const Account = () => {
         setUser(testProfiles as Profile);
         if (testProfiles.emoji) setSelectedEmoji(testProfiles.emoji);
         if (testProfiles.age !== undefined && testProfiles.age !== null) setAge(testProfiles.age);
-        setWantsUpdates(!!testProfiles.wants_updates);
-        setWantsReminders(testProfiles.wants_reminders !== false);
-        setWantsNotifications(!!testProfiles.wants_notifications);
-        setIsPrivate(!!testProfiles.is_private);
+        setWantsUpdates(!!testProfiles.wantsUpdates);
+        setWantsReminders(testProfiles.wantsReminders !== false);
+        setWantsNotifications(!!testProfiles.wantsNotifications);
+        setIsPrivate(!!testProfiles.isPrivate);
       } else {
         setUser(null);
       }
@@ -154,10 +154,10 @@ const Account = () => {
       await requestBrowserNotificationPermission();
     }
     const { error } = await supabase.from('profiles').update({
-      wants_updates: wantsUpdates,
-      wants_reminders: wantsReminders,
-      wants_notifications: wantsNotifications,
-      is_private: isPrivate
+      wantsUpdates,
+      wantsReminders,
+      wantsNotifications,
+      isPrivate
     }).eq('id', user.id);
     if (error) {
       console.error('Fout bij opslaan voorkeuren:', error);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,9 +18,9 @@ interface Invitation {
 
 interface Profile {
   id: string;
-  full_name: string;
+  fullName: string;
   emoji?: string;
-  last_seen?: string;
+  lastSeen?: string;
   email?: string;
 }
 
@@ -64,19 +64,19 @@ const Dashboard = () => {
         navigate('/login');
         return;
       }
-      // Update last_seen on dashboard visit
+      // Update lastSeen on dashboard visit
       await supabase
         .from('profiles')
-        .update({ last_seen: new Date().toISOString() })
+        .update({ lastSeen: new Date().toISOString() })
         .eq('id', session.user.id);
       // Onboarding check: only show for new signups
       if (localStorage.getItem('anemi-show-onboarding')) {
         setShowOnboarding(true);
       }
-      // Profiel ophalen (inclusief last_seen)
+      // Profiel ophalen (inclusief lastSeen)
       const { data: profileData } = await supabase
         .from('profiles')
-        .select('id, full_name, emoji, last_seen')
+        .select('id, fullName, emoji, lastSeen')
         .eq('id', session.user.id)
         .maybeSingle();
       setProfile(profileData as Profile);
@@ -93,14 +93,14 @@ const Dashboard = () => {
         if (acceptedIds.length > 0) {
           const { data: friendProfiles } = await supabase
             .from('profiles')
-            .select('id, full_name, emoji, email')
+            .select('id, fullName, emoji, email')
             .in('id', acceptedIds);
           friendsList = friendProfiles || [];
         }
         if (pendingIds.length > 0) {
           const { data: pendingProfiles } = await supabase
             .from('profiles')
-            .select('id, full_name, emoji, email')
+            .select('id, fullName, emoji, email')
             .in('id', pendingIds);
           pendingList = pendingProfiles || [];
         }
@@ -151,7 +151,7 @@ const Dashboard = () => {
 
   const filteredFriends = useMemo(() =>
     friends.filter(f =>
-      f.full_name.toLowerCase().includes(friendSearch.toLowerCase()) ||
+      f.fullName.toLowerCase().includes(friendSearch.toLowerCase()) ||
       (f.email ? f.email.toLowerCase().includes(friendSearch.toLowerCase()) : false)
     ),
   [friends, friendSearch]);
@@ -295,14 +295,14 @@ const Dashboard = () => {
       )}
       {/* Welkomstbericht */}
       <div className="flex items-center gap-3 mb-6">
-        {profile?.emoji && <span className="text-4xl" title={profile.full_name}>{profile.emoji}</span>}
+        {profile?.emoji && <span className="text-4xl" title={profile.fullName}>{profile.emoji}</span>}
         <div>
           <h1 className="text-2xl sm:text-3xl font-bold text-primary-700 mb-1">
-            {t('dashboard.welcome')}, {profile?.full_name || t('dashboard.user')}!
+            {t('dashboard.welcome')}, {profile?.fullName || t('dashboard.user')}!
           </h1>
           {profile && (
             <div className="text-gray-600 text-sm">
-              {t('dashboard.lastLogin', { date: profile.last_seen ? new Date(profile.last_seen).toLocaleDateString() : '' })}
+              {t('dashboard.lastLogin', { date: profile.lastSeen ? new Date(profile.lastSeen).toLocaleDateString() : '' })}
             </div>
           )}
         </div>
@@ -332,8 +332,8 @@ const Dashboard = () => {
           <ul className="flex flex-wrap gap-3">
             {filteredFriends.map(friend => (
               <li key={friend.id} className="flex items-center gap-2 bg-white/80 rounded-xl shadow px-4 py-2 border border-primary-100">
-                {friend.emoji && <span className="text-2xl" title={friend.full_name}>{friend.emoji}</span>}
-                <span className="font-semibold text-primary-700">{friend.full_name}</span>
+                {friend.emoji && <span className="text-2xl" title={friend.fullName}>{friend.emoji}</span>}
+                <span className="font-semibold text-primary-700">{friend.fullName}</span>
                 {friend.email ? (
                   <span className="ml-2 text-green-600 text-xs font-semibold">{t('dashboard.hasAccount', 'Has account')}</span>
                 ) : (
@@ -361,8 +361,8 @@ const Dashboard = () => {
           <ul className="flex flex-wrap gap-3">
             {pendingFriends.map(friend => (
               <li key={friend.id} className="flex items-center gap-2 bg-yellow-50 rounded-xl shadow px-4 py-2 border border-yellow-200">
-                {friend.emoji && <span className="text-2xl" title={friend.full_name}>{friend.emoji}</span>}
-                <span className="font-semibold text-yellow-700">{friend.full_name}</span>
+                {friend.emoji && <span className="text-2xl" title={friend.fullName}>{friend.emoji}</span>}
+                <span className="font-semibold text-yellow-700">{friend.fullName}</span>
                 <span className="ml-2 text-xs text-yellow-600">{t('dashboard.pending', 'Pending')}</span>
               </li>
             ))}

--- a/src/pages/InviteFriend.tsx
+++ b/src/pages/InviteFriend.tsx
@@ -10,7 +10,7 @@ const InviteFriend = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
-  const [inviter, setInviter] = useState<{ full_name: string; emoji?: string } | null>(null);
+  const [inviter, setInviter] = useState<{ fullName: string; emoji?: string } | null>(null);
 
   useEffect(() => {
     const checkInvite = async () => {
@@ -40,7 +40,7 @@ const InviteFriend = () => {
       // Get inviter profile
       const { data: inviterProfile } = await supabase
         .from('profiles')
-        .select('full_name, emoji')
+        .select('fullName, emoji')
         .eq('id', invite.inviter_id)
         .maybeSingle();
       setInviter(inviterProfile);
@@ -97,7 +97,7 @@ const InviteFriend = () => {
         <>
           <div className="mb-6">
             <span className="text-4xl">{inviter.emoji || '👤'}</span>
-            <div className="mt-2 text-lg">{t('inviteFriend.inviteFrom', 'You have been invited by')} <b>{inviter.full_name}</b></div>
+            <div className="mt-2 text-lg">{t('inviteFriend.inviteFrom', 'You have been invited by')} <b>{inviter.fullName}</b></div>
           </div>
           <button className="btn-primary" onClick={handleAccept}>{t('inviteFriend.accept', 'Accept invite')}</button>
         </>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -76,7 +76,7 @@ const Signup = () => {
       email: form.email,
       password: form.password,
       options: {
-        data: { full_name: form.name }
+        data: { fullName: form.name }
       }
     });
     if (signUpError) {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -9,7 +9,7 @@
 export interface Profile {
   id: string;
   email: string;
-  full_name: string;
+  fullName: string;
   avatar_url?: string;
   created_at: string;
   updated_at: string;
@@ -59,7 +59,7 @@ export interface Community {
   created_by: string;
   created_at: string;
   updated_at: string;
-  is_private: boolean;
+  isPrivate: boolean;
   avatar_url?: string;
   banner_url?: string;
 }

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -12,7 +12,7 @@ export function isProfile(value: unknown): value is TableRow<'profiles'> {
   return (
     typeof profile.id === 'string' &&
     typeof profile.email === 'string' &&
-    typeof profile.full_name === 'string' &&
+    typeof profile.fullName === 'string' &&
     (profile.avatar_url === undefined || typeof profile.avatar_url === 'string') &&
     typeof profile.created_at === 'string' &&
     typeof profile.updated_at === 'string' &&
@@ -74,7 +74,7 @@ export function isCommunity(value: unknown): value is TableRow<'communities'> {
     typeof community.created_by === 'string' &&
     typeof community.created_at === 'string' &&
     typeof community.updated_at === 'string' &&
-    typeof community.is_private === 'boolean' &&
+    typeof community.isPrivate === 'boolean' &&
     (community.avatar_url === undefined || typeof community.avatar_url === 'string') &&
     (community.banner_url === undefined || typeof community.banner_url === 'string')
   );

--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -16,7 +16,7 @@ async function wantsReminders(
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('wants_reminders')
+    .select('wantsReminders')
     .eq('id', user.id)
     .maybeSingle();
 
@@ -24,7 +24,7 @@ async function wantsReminders(
     return false;
   }
 
-  return !!profile?.wants_reminders;
+  return !!profile?.wantsReminders;
 }
 
 Deno.serve(async (req) => {

--- a/supabase/functions/send-meeting-reminders/index.ts
+++ b/supabase/functions/send-meeting-reminders/index.ts
@@ -14,13 +14,13 @@ async function wantsReminders(
   }
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('wants_reminders')
+    .select('wantsReminders')
     .eq('id', user.id)
     .maybeSingle();
   if (profileError) {
     return false;
   }
-  return !!profile?.wants_reminders;
+  return !!profile?.wantsReminders;
 }
 
 const slots: Record<string, [string, string]> = {

--- a/supabase/migrations/20240320_add_wants_reminders.sql
+++ b/supabase/migrations/20240320_add_wants_reminders.sql
@@ -1,1 +1,1 @@
-ALTER TABLE profiles ADD COLUMN wants_reminders boolean NOT NULL DEFAULT true;
+ALTER TABLE profiles ADD COLUMN wantsReminders boolean NOT NULL DEFAULT true;

--- a/supabase/migrations/20240517_add_wants_notifications.sql
+++ b/supabase/migrations/20240517_add_wants_notifications.sql
@@ -1,1 +1,1 @@
-ALTER TABLE profiles ADD COLUMN wants_notifications boolean NOT NULL DEFAULT false;
+ALTER TABLE profiles ADD COLUMN wantsNotifications boolean NOT NULL DEFAULT false;

--- a/supabase/migrations/20250607_rename_profile_columns.sql
+++ b/supabase/migrations/20250607_rename_profile_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE profiles RENAME COLUMN wants_updates TO wantsUpdates;
+ALTER TABLE profiles RENAME COLUMN wants_reminders TO wantsReminders;
+ALTER TABLE profiles RENAME COLUMN wants_notifications TO wantsNotifications;
+ALTER TABLE profiles RENAME COLUMN is_private TO isPrivate;
+ALTER TABLE profiles RENAME COLUMN full_name TO fullName;


### PR DESCRIPTION
## Summary
- rename profile preference columns to camelCase
- update migrations and Supabase functions
- adjust TypeScript interfaces and pages accordingly

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef251008832d80ccd71195eab0ed