### PR TITLE
Add shared helper functions

### DIFF
--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -1,31 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-function encodeBase64(str: string) {
-  return btoa(unescape(encodeURIComponent(str)));
-}
-
-async function wantsReminders(
-  supabase: ReturnType<typeof createClient>,
-  email: string
-): Promise<boolean> {
-  const { data: user, error: userError } = await supabase.auth.admin.getUserByEmail(email);
-
-  if (userError || !user) {
-    return false;
-  }
-
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('wantsReminders')
-    .eq('id', user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    return false;
-  }
-
-  return !!profile?.wantsReminders;
-}
+import { encodeBase64, wantsReminders } from "../shared.ts";
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {

--- a/supabase/functions/send-meeting-reminders/index.ts
+++ b/supabase/functions/send-meeting-reminders/index.ts
@@ -1,27 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-function encodeBase64(str: string) {
-  return btoa(unescape(encodeURIComponent(str)));
-}
-
-async function wantsReminders(
-  supabase: ReturnType<typeof createClient>,
-  email: string
-): Promise<boolean> {
-  const { data: user, error: userError } = await supabase.auth.admin.getUserByEmail(email);
-  if (userError || !user) {
-    return false;
-  }
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('wantsReminders')
-    .eq('id', user.id)
-    .maybeSingle();
-  if (profileError) {
-    return false;
-  }
-  return !!profile?.wantsReminders;
-}
+import { encodeBase64, wantsReminders } from "../shared.ts";
 
 const slots: Record<string, [string, string]> = {
   morning: ["T090000", "T120000"],

--- a/supabase/functions/shared.ts
+++ b/supabase/functions/shared.ts
@@ -1,0 +1,28 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export function encodeBase64(str: string): string {
+  return btoa(unescape(encodeURIComponent(str)));
+}
+
+export async function wantsReminders(
+  supabase: ReturnType<typeof createClient>,
+  email: string,
+): Promise<boolean> {
+  const { data: user, error: userError } = await supabase.auth.admin.getUserByEmail(email);
+
+  if (userError || !user) {
+    return false;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('wantsReminders')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    return false;
+  }
+
+  return !!profile?.wantsReminders;
+}


### PR DESCRIPTION
## Summary
- add `shared.ts` with `encodeBase64` and `wantsReminders`
- reuse helpers in `send-meeting-confirmation` and `send-meeting-reminders`

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6843f1c83ffc832d85dd4a2698718adb