### PR TITLE
Add invitation RLS policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ supabase functions deploy send-meeting-reminders --project-ref <your-project-id>
 ```
 
 Configure the schedule for this function in `supabase/config.toml`. See the [Supabase docs](https://supabase.com/docs/guides/functions/schedule-functions) for details.
+## Invitation Security
+
+Row level security is enabled on the `invitations` table. A signed-in user can read or modify a row when their user ID matches `invitee_id` or their email matches `email_a` or `email_b`. Inserts require `email_a` to equal the authenticated user's email.
+
 
 ## Contributing
 

--- a/supabase/migrations/20250822_enable_rls_invitations.sql
+++ b/supabase/migrations/20250822_enable_rls_invitations.sql
@@ -1,0 +1,25 @@
+ALTER TABLE invitations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow users to read their invitations" ON invitations
+FOR SELECT USING (
+  auth.uid() = invitee_id
+  OR auth.email() = email_a
+  OR auth.email() = email_b
+);
+
+CREATE POLICY "Allow users to insert invitations for themselves" ON invitations
+FOR INSERT WITH CHECK (
+  auth.email() = email_a
+);
+
+CREATE POLICY "Allow users to update their invitations" ON invitations
+FOR UPDATE USING (
+  auth.uid() = invitee_id
+  OR auth.email() = email_a
+  OR auth.email() = email_b
+);
+
+CREATE POLICY "Allow users to delete their invitations" ON invitations
+FOR DELETE USING (
+  auth.email() = email_a
+);


### PR DESCRIPTION
## Summary
- enable row level security on `invitations`
- add policies for viewing and modifying only a user's invitations
- document new invitation security rules

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6843f24188b0832db9383120962efb9d