### PR TITLE
Add Supabase buckets and policies

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -94,12 +94,18 @@ file_size_limit = "50MiB"
 # [storage.image_transformation]
 # enabled = true
 
-# Uncomment to configure local storage buckets
-# [storage.buckets.images]
-# public = false
-# file_size_limit = "50MiB"
-# allowed_mime_types = ["image/png", "image/jpeg"]
-# objects_path = "./images"
+# Configure local storage buckets
+[storage.buckets.cafes]
+public = false
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/png", "image/jpeg"]
+objects_path = "./cafes"
+
+[storage.buckets.avatars]
+public = false
+file_size_limit = "5MiB"
+allowed_mime_types = ["image/png", "image/jpeg"]
+objects_path = "./avatars"
 
 [auth]
 enabled = true

--- a/supabase/migrations/20250608_create_storage_buckets.sql
+++ b/supabase/migrations/20250608_create_storage_buckets.sql
@@ -1,0 +1,29 @@
+-- Create buckets for cafe images and user avatars
+insert into storage.buckets (id, name, public)
+values
+  ('cafes', 'cafes', false),
+  ('avatars', 'avatars', false)
+  on conflict (id) do nothing;
+
+-- Enable RLS on objects table
+alter table storage.objects enable row level security;
+
+-- Policies for cafe images
+create policy "cafes_read" on storage.objects
+  for select using (bucket_id = 'cafes');
+create policy "cafes_insert" on storage.objects
+  for insert with check (bucket_id = 'cafes' and owner = auth.uid());
+create policy "cafes_update" on storage.objects
+  for update using (bucket_id = 'cafes' and owner = auth.uid());
+create policy "cafes_delete" on storage.objects
+  for delete using (bucket_id = 'cafes' and owner = auth.uid());
+
+-- Policies for user avatars
+create policy "avatars_read" on storage.objects
+  for select using (bucket_id = 'avatars');
+create policy "avatars_insert" on storage.objects
+  for insert with check (bucket_id = 'avatars' and owner = auth.uid());
+create policy "avatars_update" on storage.objects
+  for update using (bucket_id = 'avatars' and owner = auth.uid());
+create policy "avatars_delete" on storage.objects
+  for delete using (bucket_id = 'avatars' and owner = auth.uid());


### PR DESCRIPTION
## Summary
- configure `cafes` and `avatars` buckets in Supabase config
- create migration to add buckets and read/write policies

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843f2428a60832d9f7b9524e9d75562