### PR TITLE
Add logger utility and improve Supabase functions

### DIFF
--- a/supabase/functions/_utils/logger.ts
+++ b/supabase/functions/_utils/logger.ts
@@ -1,0 +1,34 @@
+import * as Sentry from "https://esm.sh/@sentry/deno@9.27.0";
+
+const dsn = Deno.env.get("SENTRY_DSN");
+if (dsn) {
+  Sentry.init({ dsn });
+}
+
+export function log(...args: unknown[]) {
+  console.log(new Date().toISOString(), ...args);
+}
+
+export function logError(error: unknown, context?: Record<string, unknown>) {
+  console.error(error);
+  if (dsn) {
+    Sentry.captureException(error, { extra: context });
+  }
+}
+
+export async function retry<T>(fn: () => Promise<T>, retries = 3, delayMs = 500): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt++;
+      log(`Retry attempt ${attempt} failed`, err);
+      if (attempt >= retries) {
+        logError(err);
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+}

--- a/supabase/functions/contact/index.ts
+++ b/supabase/functions/contact/index.ts
@@ -1,4 +1,5 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { log, logError } from "../_utils/logger.ts";
 
 Deno.serve(async (req: Request) => {
   if (req.method !== 'POST') {
@@ -7,24 +8,26 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  interface ContactBody { name: string; email: string; message: string }
-  let body: ContactBody;
   try {
-    body = await req.json();
-  } catch {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400 });
-  }
+    interface ContactBody { name: string; email: string; message: string }
+    const body: ContactBody = await req.json();
 
-  const { name, email, message } = body;
-  if (!name || !email || !message) {
-    return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
-  }
+    const { name, email, message } = body;
+    if (!name || !email || !message) {
+      return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
+    }
 
-  return new Response(
-    JSON.stringify({
-      success: true,
-      received: { name, email, message, receivedAt: new Date().toISOString() },
-    }),
-    { status: 200 },
-  );
+    log('Contact request', { name, email });
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        received: { name, email, message, receivedAt: new Date().toISOString() },
+      }),
+      { status: 200 },
+    );
+  } catch (e) {
+    logError(e);
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), { status: 500 });
+  }
 });

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,5 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { log, logError, retry } from "../_utils/logger.ts";
 
 // @ts-expect-error Deno globals are available in Edge Functions
 Deno.serve(async (req: Request) => {
@@ -7,55 +8,61 @@ Deno.serve(async (req: Request) => {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
   }
 
-  const supabaseUrl = Deno.env.get('SUPABASE_URL');
-  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-  if (!supabaseUrl || !serviceRoleKey) {
-    return new Response(JSON.stringify({ error: 'Missing server config' }), { status: 500 });
-  }
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!supabaseUrl || !serviceRoleKey) {
+      throw new Error('Missing server config');
+    }
 
-  // Haal JWT uit Authorization header
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return new Response(JSON.stringify({ error: 'Missing authorization' }), { status: 401 });
-  }
-  const jwt = authHeader.replace('Bearer ', '');
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return new Response(JSON.stringify({ error: 'Missing authorization' }), { status: 401 });
+    }
+    const jwt = authHeader.replace('Bearer ', '');
 
-  // Verify JWT via Supabase
-  const supabase = createClient(supabaseUrl, serviceRoleKey);
-  const { data, error: verifyError } = await supabase.auth.getUser(jwt);
-  if (verifyError || !data?.user) {
-    return new Response(JSON.stringify({ error: 'Invalid token' }), { status: 401 });
-  }
-  const userId = data.user.id;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const { data, error: verifyError } = await retry(() => supabase.auth.getUser(jwt));
+    if (verifyError || !data?.user) {
+      return new Response(JSON.stringify({ error: 'Invalid token' }), { status: 401 });
+    }
+    const userId = data.user.id;
 
-  // Verwijder uit Auth
-  const adminRes = await fetch(`${supabaseUrl}/auth/v1/admin/users/${userId}`, {
-    method: 'DELETE',
-    headers: {
-      'apikey': serviceRoleKey,
-      'Authorization': `Bearer ${serviceRoleKey}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!adminRes.ok) {
-    const err = await adminRes.text();
-    return new Response(JSON.stringify({ error: 'Failed to delete user', details: err }), { status: 500 });
-  }
+    const adminRes = await retry(() =>
+      fetch(`${supabaseUrl}/auth/v1/admin/users/${userId}`, {
+        method: 'DELETE',
+        headers: {
+          apikey: serviceRoleKey,
+          Authorization: `Bearer ${serviceRoleKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+    if (!adminRes.ok) {
+      const err = await adminRes.text();
+      throw new Error('Failed to delete user: ' + err);
+    }
 
-  // Verwijder profiel
-  const dbRes = await fetch(`${supabaseUrl}/rest/v1/profiles?id=eq.${userId}`, {
-    method: 'DELETE',
-    headers: {
-      'apikey': serviceRoleKey,
-      'Authorization': `Bearer ${serviceRoleKey}`,
-      'Content-Type': 'application/json',
-      'Prefer': 'return=minimal',
-    },
-  });
-  if (!dbRes.ok) {
-    const err = await dbRes.text();
-    return new Response(JSON.stringify({ error: 'Failed to delete profile', details: err }), { status: 500 });
-  }
+    const dbRes = await retry(() =>
+      fetch(`${supabaseUrl}/rest/v1/profiles?id=eq.${userId}`, {
+        method: 'DELETE',
+        headers: {
+          apikey: serviceRoleKey,
+          Authorization: `Bearer ${serviceRoleKey}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        },
+      })
+    );
+    if (!dbRes.ok) {
+      const err = await dbRes.text();
+      throw new Error('Failed to delete profile: ' + err);
+    }
 
-  return new Response(JSON.stringify({ success: true }), { status: 200 });
+    log('Deleted account', { userId });
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  } catch (e) {
+    logError(e);
+    return new Response(JSON.stringify({ error: e.message ?? 'Unexpected error' }), { status: 500 });
+  }
 });

--- a/supabase/functions/report-issue/index.ts
+++ b/supabase/functions/report-issue/index.ts
@@ -1,38 +1,42 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { log, logError } from "../_utils/logger.ts";
 
 Deno.serve(async (req: Request) => {
   if (req.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
   }
 
-  interface ReportBody {
-    description: string;
-    steps?: string;
-    screenshot?: string | null;
-    context?: unknown;
-  }
-  let body: ReportBody;
   try {
-    body = await req.json();
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400 });
-  }
-
-  const { description, steps, screenshot, context } = body;
-  if (!description) {
-    return new Response(JSON.stringify({ error: 'Description is required' }), { status: 400 });
-  }
-
-  // For MVP: just echo back the received data
-  // In production: store in DB, send email/Slack, etc.
-  return new Response(JSON.stringify({
-    success: true,
-    received: {
-      description,
-      steps,
-      hasScreenshot: !!screenshot,
-      context,
-      receivedAt: new Date().toISOString(),
+    interface ReportBody {
+      description: string;
+      steps?: string;
+      screenshot?: string | null;
+      context?: unknown;
     }
-  }), { status: 200 });
+    const body: ReportBody = await req.json();
+
+    const { description, steps, screenshot, context } = body;
+    if (!description) {
+      return new Response(JSON.stringify({ error: 'Description is required' }), { status: 400 });
+    }
+
+    log('Issue reported');
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        received: {
+          description,
+          steps,
+          hasScreenshot: !!screenshot,
+          context,
+          receivedAt: new Date().toISOString(),
+        }
+      }),
+      { status: 200 }
+    );
+  } catch (e) {
+    logError(e);
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), { status: 500 });
+  }
 });


### PR DESCRIPTION
## Summary
- add `supabase/functions/_utils/logger.ts` with retry and Sentry support
- refactor edge functions to use the logger and wrap external calls

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6843f2415168832d9c75b71fb853d2cc