### PR TITLE
Move shared interfaces to src/types

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -9,33 +9,12 @@ import FormStatus from '../components/FormStatus';
 import Toast from '../components/Toast';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { requestBrowserNotificationPermission } from '../utils/browserNotifications';
+import type { UserProfile, Invitation } from '../types/models';
 
-// TypeScript interfaces voor typeveiligheid
-interface Profile {
-  id: string;
-  fullName: string;
-  email: string;
-  emoji?: string;
-  gender?: string;
-  age?: number;
-  wantsUpdates: boolean;
-  wantsReminders?: boolean;
-  wantsNotifications?: boolean;
-  isPrivate: boolean;
-}
-
-interface Invitation {
-  id: string;
-  selected_date: string;
-  selected_time: string;
-  cafe_id?: string;
-  cafe_name?: string;
-  status: string;
-  email_b?: string;
-}
+// TypeScript interfaces voor typeveiligheid are now imported from src/types/models
 
 const Account = () => {
-  const [user, setUser] = useState<Profile | null>(null);
+  const [user, setUser] = useState<UserProfile | null>(null);
   const [selectedEmoji, setSelectedEmoji] = useState<string>('');
   const [age, setAge] = useState<number | ''>('');
   const [myMeetups, setMyMeetups] = useState<Invitation[]>([]);
@@ -82,7 +61,7 @@ const Account = () => {
         console.error('Fout bij ophalen profiel:', testProfilesError);
       }
       if (testProfiles) {
-        setUser(testProfiles as Profile);
+        setUser(testProfiles as UserProfile);
         if (testProfiles.emoji) setSelectedEmoji(testProfiles.emoji);
         if (testProfiles.age !== undefined && testProfiles.age !== null) setAge(testProfiles.age);
         setWantsUpdates(!!testProfiles.wantsUpdates);

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -6,13 +6,9 @@ import "react-datepicker/dist/react-datepicker.css";
 import DateSelector from '../components/meetups/DateSelector';
 import { useNavigate } from 'react-router-dom';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { City, Cafe, BasicUser } from '../types/models';
 
-interface City { id: string; name: string; }
-interface Cafe { id: string; name: string; address: string; description?: string; image_url?: string; }
-
-interface User {
-  email: string;
-}
+// Common interfaces imported from src/types/models
 
 const getLastCity = () => {
   if (typeof window !== 'undefined') {
@@ -58,7 +54,7 @@ const CreateMeetup = () => {
   const [shuffleCooldown, setShuffleCooldown] = useState(false);
   const shuffleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [step, setStep] = useState(1);
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<BasicUser | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [isLoadingCities, setIsLoadingCities] = useState(true);
   const [cityError, setCityError] = useState<string | null>(null);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,24 +5,9 @@ import { useTranslation } from 'react-i18next';
 import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
 import OnboardingModal from '../components/OnboardingModal';
+import type { Invitation, UserProfile } from '../types/models';
 
-interface Invitation {
-  id: string;
-  selected_date: string;
-  selected_time: string;
-  cafe_id?: string;
-  cafe_name?: string;
-  status: string;
-  email_b?: string;
-}
-
-interface Profile {
-  id: string;
-  fullName: string;
-  emoji?: string;
-  lastSeen?: string;
-  email?: string;
-}
+// Interfaces are now imported from src/types/models
 
 const Dashboard = () => {
   const { t, i18n } = useTranslation();
@@ -30,10 +15,10 @@ const Dashboard = () => {
   const [meetups, setMeetups] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
-  const [friends, setFriends] = useState<Profile[]>([]);
-  const [pendingFriends, setPendingFriends] = useState<Profile[]>([]);
+  const [friends, setFriends] = useState<UserProfile[]>([]);
+  const [pendingFriends, setPendingFriends] = useState<UserProfile[]>([]);
   const [inviteCode, setInviteCode] = useState<string | null>(null);
   const [inviteLoading, setInviteLoading] = useState(false);
   const [addFriendValue, setAddFriendValue] = useState('');
@@ -79,14 +64,14 @@ const Dashboard = () => {
         .select('id, fullName, emoji, lastSeen')
         .eq('id', session.user.id)
         .maybeSingle();
-      setProfile(profileData as Profile);
+      setProfile(profileData as UserProfile);
       // Friends ophalen (accepted)
       const { data: friendshipRows } = await supabase
         .from('friendships')
         .select('friend_id, status')
         .eq('user_id', session.user.id);
-      let friendsList: Profile[] = [];
-      let pendingList: Profile[] = [];
+      let friendsList: UserProfile[] = [];
+      let pendingList: UserProfile[] = [];
       if (friendshipRows && friendshipRows.length > 0) {
         const acceptedIds = friendshipRows.filter((f: { friend_id: string, status: string }) => f.status === 'accepted').map((f: { friend_id: string }) => f.friend_id);
         const pendingIds = friendshipRows.filter((f: { friend_id: string, status: string }) => f.status === 'pending').map((f: { friend_id: string }) => f.friend_id);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import LoadingIndicator from '../components/LoadingIndicator';
 import FormStatus from '../components/FormStatus';
 import Toast from '../components/Toast';
 import ErrorBoundary from '../components/ErrorBoundary';
+import type { AuthError } from '../types/models';
 
 const UPDATES_EMAIL_KEY = 'anemi-updates-email';
 
@@ -43,7 +44,6 @@ const Login = () => {
     }
   }, []);
 
-  interface AuthError { code?: string; message?: string }
   function normalizeAuthError(t: TFunction, error: AuthError) {
     let msg = t('error_generic');
     const code = error.code || '';

--- a/src/pages/Meetups.tsx
+++ b/src/pages/Meetups.tsx
@@ -3,20 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import { useTranslation } from 'react-i18next';
 import Toast from '../components/Toast';
+import type { Meetup } from '../types/models';
 
-interface Meetup {
-  id: string;
-  title?: string;
-  description?: string;
-  selected_date: string;
-  selected_time: string;
-  cafe_id?: string;
-  cafe_name?: string;
-  status?: string;
-  email_b?: string;
-  invitee_id?: string;
-  token?: string;
-}
+// Interface Meetup is imported from src/types/models
 
 const LOCAL_CACHE_KEY = 'meetups_cache_v1';
 

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -6,23 +6,9 @@ import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
 import FormStatus from '../components/FormStatus';
 import type { TFunction, i18n as I18n } from 'i18next';
+import type { Invitation, Cafe, ConfirmationInfo } from '../types/models';
 
-// TypeScript interfaces voor typeveiligheid
-interface Invitation {
-  token: string;
-  cafe_id?: string;
-  cafe_name?: string;
-  cafe_address?: string;
-  date_time_options?: { date: string; times: string[] }[];
-}
-interface Cafe { name: string; address: string; image_url?: string; }
-interface ConfirmationInfo {
-  cafe_name: string;
-  cafe_address: string;
-  selected_date: string;
-  selected_time: string;
-  ics_base64?: string;
-}
+// Common interfaces are imported from src/types/models
 
 const Respond = () => {
   const { t, i18n: _i18n } = useTranslation();
@@ -53,7 +39,7 @@ const Respond = () => {
   }
 
   function mapRespondError(t: TFunction, data: { error?: string; error_code?: string }, _i18n: I18n) {
-    let msg = getRespondErrorMessage(t, 'respond.genericError', data.error);
+    let msg = getRespondErrorMessage(t, 'respond.genericError', data.error ? { message: data.error } : null);
     if (data.error && typeof data.error === 'string') {
       const err = data.error.toLowerCase();
       if (err.includes('missing email')) {
@@ -69,9 +55,9 @@ const Respond = () => {
           ? 'Deze uitnodiging is niet meer geldig. Vraag je vriend(in) om een nieuwe link!'
           : 'This invite link is no longer valid. Ask your friend for a new one!';
       } else if (err.includes('authorization')) {
-        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error);
+        msg = getRespondErrorMessage(t, 'respond.errorSendMail', { message: data.error });
       } else if (err.includes('expired') || err.includes('not found')) {
-        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error);
+        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', { message: data.error });
       }
     }
     const code = data.error_code || '';
@@ -87,10 +73,10 @@ const Respond = () => {
           : 'Please enter your email address!';
         break;
       case 'authorization':
-        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error);
+        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error ? { message: data.error } : null);
         break;
       case 'expired_or_missing':
-        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error);
+        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error ? { message: data.error } : null);
         break;
       default:
         // already handled above
@@ -237,12 +223,12 @@ const Respond = () => {
       }
 
       const body: ConfirmRequestBody = {
-        token: invitation.token,
+        token: invitation.token!,
         email: formData.email,
         email_b: formData.email,
         selected_date: datePart,
         selected_time: timePart,
-        cafe_id: cafeId
+        cafe_id: cafeId!
       };
       const authKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
       const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/send-meeting-confirmation`, {
@@ -272,7 +258,7 @@ const Respond = () => {
         });
       }
     } catch (err) {
-      setErrorMsg(getRespondErrorMessage(t, 'respond.genericError', err));
+      setErrorMsg(getRespondErrorMessage(t, 'respond.genericError', err as GenericError));
       console.error("Netwerkfout:", err);
     }
   };

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -2,14 +2,9 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import { useTranslation } from 'react-i18next';
+import type { SignupForm } from '../types/models';
 
-// TypeScript interface voor typeveiligheid
-interface SignupForm {
-  name: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-}
+// Common interfaces are imported from src/types/models
 
 const Signup = () => {
   const navigate = useNavigate();

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,78 @@
+export interface UserProfile {
+  id: string;
+  fullName: string;
+  email?: string;
+  emoji?: string;
+  gender?: string;
+  age?: number;
+  lastSeen?: string;
+  wantsUpdates?: boolean;
+  wantsReminders?: boolean;
+  wantsNotifications?: boolean;
+  isPrivate?: boolean;
+}
+
+export interface Invitation {
+  id: string;
+  selected_date: string;
+  selected_time: string;
+  status: string;
+  token?: string;
+  cafe_id?: string;
+  cafe_name?: string;
+  cafe_address?: string;
+  date_time_options?: { date: string; times: string[] }[];
+  email_b?: string;
+  invitee_id?: string;
+}
+
+export interface City {
+  id: string;
+  name: string;
+}
+
+export interface Cafe {
+  id: string;
+  name: string;
+  address: string;
+  description?: string;
+  image_url?: string;
+}
+
+export interface BasicUser {
+  email?: string;
+}
+
+export interface Meetup {
+  id: string;
+  title?: string;
+  description?: string;
+  selected_date: string;
+  selected_time: string;
+  cafe_id?: string;
+  cafe_name?: string;
+  status?: string;
+  email_b?: string;
+  invitee_id?: string;
+  token?: string;
+}
+
+export interface ConfirmationInfo {
+  cafe_name?: string;
+  cafe_address?: string;
+  selected_date: string;
+  selected_time: string;
+  ics_base64?: string;
+}
+
+export interface SignupForm {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface AuthError {
+  code?: string;
+  message?: string;
+}

--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -8,7 +8,7 @@ export const handleApiError = (error: unknown): ApiError => {
   if (typeof error === 'object' && error !== null && (error as AxiosError).isAxiosError === true) {
     const axiosError = error as AxiosError;
     const status = axiosError.response?.status;
-    const data = axiosError.response?.data;
+    const data = axiosError.response?.data as { message?: string } | undefined;
 
     // Handle specific HTTP status codes
     switch (status) {


### PR DESCRIPTION
## Summary
- centralize interface declarations under `src/types/models.ts`
- import new shared types across pages
- enforce `@typescript-eslint/no-explicit-any` (already enabled) and adjust code
- fix type issues flagged by `tsc`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843f1c6853c832da27dbb6509500616