### PR TITLE
Introduce supabase service helpers

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { getProfile } from '../services/supabaseService';
 import { useTranslation } from 'react-i18next';
 import type { TFunction, i18n as I18n } from 'i18next';
 import SkeletonLoader from '../components/SkeletonLoader';
@@ -77,18 +78,18 @@ const Account = () => {
         return;
       }
       // Haal profiel op
-      const { data: testProfiles, error: testProfilesError } = await supabase.from('profiles').select('*').eq('id', session.user.id).maybeSingle();
-      if (testProfilesError) {
-        console.error('Fout bij ophalen profiel:', testProfilesError);
+      const { data: profileData, error: profileError } = await getProfile(session.user.id);
+      if (profileError) {
+        console.error('Fout bij ophalen profiel:', profileError);
       }
-      if (testProfiles) {
-        setUser(testProfiles as Profile);
-        if (testProfiles.emoji) setSelectedEmoji(testProfiles.emoji);
-        if (testProfiles.age !== undefined && testProfiles.age !== null) setAge(testProfiles.age);
-        setWantsUpdates(!!testProfiles.wantsUpdates);
-        setWantsReminders(testProfiles.wantsReminders !== false);
-        setWantsNotifications(!!testProfiles.wantsNotifications);
-        setIsPrivate(!!testProfiles.isPrivate);
+      if (profileData) {
+        setUser(profileData as Profile);
+        if (profileData.emoji) setSelectedEmoji(profileData.emoji);
+        if (profileData.age !== undefined && profileData.age !== null) setAge(profileData.age);
+        setWantsUpdates(!!profileData.wantsUpdates);
+        setWantsReminders(profileData.wantsReminders !== false);
+        setWantsNotifications(!!profileData.wantsNotifications);
+        setIsPrivate(!!profileData.isPrivate);
       } else {
         setUser(null);
       }

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '../supabaseClient';
+import { createInvitation } from '../services/supabaseService';
 import "react-datepicker/dist/react-datepicker.css";
 import DateSelector from '../components/meetups/DateSelector';
 import { useNavigate } from 'react-router-dom';
-import type { SupabaseClient } from '@supabase/supabase-js';
 
 interface City { id: string; name: string; }
 interface Cafe { id: string; name: string; address: string; description?: string; image_url?: string; }
@@ -23,13 +23,13 @@ const getLastCity = () => {
 
 const QUEUE_KEY = 'meetups_queue_v1';
 
-async function flushMeetupQueue(supabase: SupabaseClient, onSuccess: () => void) {
+async function flushMeetupQueue(onSuccess: () => void) {
   const queue = JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]');
   if (!queue.length) return;
   const newQueue = [];
   for (const payload of queue) {
     try {
-      const { error } = await supabase.from('invitations').insert(payload);
+      const { error } = await createInvitation(payload);
       if (error) {
         newQueue.push(payload); // niet gelukt, blijft in queue
       } else {
@@ -171,7 +171,7 @@ const CreateMeetup = () => {
 
   // Flush queue bij online komen
   useEffect(() => {
-    const flush = () => flushMeetupQueue(supabase, () => {});
+    const flush = () => flushMeetupQueue(() => {});
     window.addEventListener('online', flush);
     // Initieel ook proberen flushen
     flush();
@@ -271,10 +271,7 @@ const CreateMeetup = () => {
       if (import.meta.env.DEV) {
         console.log('Attempting to insert invitation...');
       }
-      const { data: insertData, error: insertError } = await supabase
-        .from('invitations')
-        .insert(payload)
-        .select();
+      const { data: insertData, error: insertError } = await createInvitation(payload);
 
       if (import.meta.env.DEV) {
         console.log('Insert result:', { data: insertData, error: insertError });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { getProfile } from '../services/supabaseService';
 import { useTranslation } from 'react-i18next';
 import LoadingIndicator from '../components/LoadingIndicator';
 import SkeletonLoader from '../components/SkeletonLoader';
@@ -74,11 +75,7 @@ const Dashboard = () => {
         setShowOnboarding(true);
       }
       // Profiel ophalen (inclusief lastSeen)
-      const { data: profileData } = await supabase
-        .from('profiles')
-        .select('id, fullName, emoji, lastSeen')
-        .eq('id', session.user.id)
-        .maybeSingle();
+      const { data: profileData } = await getProfile(session.user.id);
       setProfile(profileData as Profile);
       // Friends ophalen (accepted)
       const { data: friendshipRows } = await supabase

--- a/src/pages/InviteFriend.tsx
+++ b/src/pages/InviteFriend.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { getProfile } from '../services/supabaseService';
 import { useTranslation } from 'react-i18next';
 
 const InviteFriend = () => {
@@ -38,11 +39,7 @@ const InviteFriend = () => {
         return;
       }
       // Get inviter profile
-      const { data: inviterProfile } = await supabase
-        .from('profiles')
-        .select('fullName, emoji')
-        .eq('id', invite.inviter_id)
-        .maybeSingle();
+      const { data: inviterProfile } = await getProfile(invite.inviter_id);
       setInviter(inviterProfile);
       setLoading(false);
     };

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -1,0 +1,29 @@
+import { supabase } from '../supabaseClient';
+import type { Database } from '../types/supabase';
+
+export type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+export type InvitationInsert = Database['public']['Tables']['invitations']['Insert'];
+export type InvitationRow = Database['public']['Tables']['invitations']['Row'];
+
+export async function getProfile(userId: string) {
+  return supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .maybeSingle();
+}
+
+export async function createInvitation(payload: InvitationInsert) {
+  return supabase
+    .from('invitations')
+    .insert(payload)
+    .select()
+    .single();
+}
+
+export const service = {
+  getProfile,
+  createInvitation,
+};
+
+export default service;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -118,6 +118,27 @@ export interface FriendInvite {
 }
 
 /**
+ * Invitation information
+ */
+export interface Invitation {
+  id: string;
+  token: string;
+  invitee_name: string;
+  status: string;
+  selected_date: string;
+  selected_time: string;
+  cafe_id: string;
+  email_a?: string;
+  email_b?: string;
+  cafe_name?: string | null;
+  date_time_options?: { date: string; times: string[] }[] | null;
+  reminded_24h?: boolean;
+  reminded_1h?: boolean;
+  created_at: string;
+  updated_at?: string;
+}
+
+/**
  * Friendship information
  */
 export interface Friendship {
@@ -169,6 +190,11 @@ export interface Database {
         Row: Notification;
         Insert: Omit<Notification, 'id' | 'created_at'>;
         Update: Partial<Omit<Notification, 'id'>>;
+      };
+      invitations: {
+        Row: Invitation;
+        Insert: Omit<Invitation, 'id' | 'created_at' | 'updated_at'>;
+        Update: Partial<Omit<Invitation, 'id'>>;
       };
     };
     Views: {


### PR DESCRIPTION
## Summary
- define `Invitation` table types
- add supabase service layer with `getProfile` and `createInvitation`
- use service helpers in pages instead of raw client calls

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6843f1c42ff0832da60960d3c34fb80c