### PR TITLE
Fix respond helper typing

### DIFF
--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -11,7 +11,7 @@ interface City { id: string; name: string; }
 interface Cafe { id: string; name: string; address: string; description?: string; image_url?: string; }
 
 interface User {
-  email: string;
+  email?: string;
 }
 
 const getLastCity = () => {

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -44,16 +44,27 @@ const Respond = () => {
   const UPDATES_EMAIL_KEY = 'anemi-updates-email';
 
   interface GenericError { message?: string }
-  function getRespondErrorMessage(t: TFunction, key: string, error: GenericError | null) {
+  function getRespondErrorMessage(
+    t: TFunction,
+    key: string,
+    error: string | GenericError | null,
+  ) {
     const translated = t(key);
     if (translated === key) {
-      return `Error: ${error?.message || 'Unknown error'}`;
+      if (error && typeof error === 'string') {
+        return `Error: ${error}`;
+      }
+      return `Error: ${(error as GenericError | null)?.message || 'Unknown error'}`;
     }
     return translated;
   }
 
-  function mapRespondError(t: TFunction, data: { error?: string; error_code?: string }, _i18n: I18n) {
-    let msg = getRespondErrorMessage(t, 'respond.genericError', data.error);
+  function mapRespondError(
+    t: TFunction,
+    data: { error?: string | GenericError | null; error_code?: string },
+    _i18n: I18n,
+  ) {
+    let msg = getRespondErrorMessage(t, 'respond.genericError', data.error ?? null);
     if (data.error && typeof data.error === 'string') {
       const err = data.error.toLowerCase();
       if (err.includes('missing email')) {
@@ -69,9 +80,9 @@ const Respond = () => {
           ? 'Deze uitnodiging is niet meer geldig. Vraag je vriend(in) om een nieuwe link!'
           : 'This invite link is no longer valid. Ask your friend for a new one!';
       } else if (err.includes('authorization')) {
-        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error);
+        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error ?? null);
       } else if (err.includes('expired') || err.includes('not found')) {
-        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error);
+        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error ?? null);
       }
     }
     const code = data.error_code || '';
@@ -87,10 +98,10 @@ const Respond = () => {
           : 'Please enter your email address!';
         break;
       case 'authorization':
-        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error);
+        msg = getRespondErrorMessage(t, 'respond.errorSendMail', data.error ?? null);
         break;
       case 'expired_or_missing':
-        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error);
+        msg = getRespondErrorMessage(t, 'respond.expiredOrMissing', data.error ?? null);
         break;
       default:
         // already handled above
@@ -242,7 +253,7 @@ const Respond = () => {
         email_b: formData.email,
         selected_date: datePart,
         selected_time: timePart,
-        cafe_id: cafeId
+        cafe_id: cafeId!
       };
       const authKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
       const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/send-meeting-confirmation`, {
@@ -272,7 +283,9 @@ const Respond = () => {
         });
       }
     } catch (err) {
-      setErrorMsg(getRespondErrorMessage(t, 'respond.genericError', err));
+      setErrorMsg(
+        getRespondErrorMessage(t, 'respond.genericError', err as GenericError),
+      );
       console.error("Netwerkfout:", err);
     }
   };

--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -8,7 +8,7 @@ export const handleApiError = (error: unknown): ApiError => {
   if (typeof error === 'object' && error !== null && (error as AxiosError).isAxiosError === true) {
     const axiosError = error as AxiosError;
     const status = axiosError.response?.status;
-    const data = axiosError.response?.data;
+    const data = axiosError.response?.data as { message?: string } | undefined;
 
     // Handle specific HTTP status codes
     switch (status) {


### PR DESCRIPTION
## Summary
- update `getRespondErrorMessage` and `mapRespondError` to accept `string`, `GenericError`, or `null`
- fix usage and casting in `Respond` page
- relax `User` type in `CreateMeetup`
- allow error message access in `apiErrorHandler`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843f8898290832daac00ffcde90c6bf