### PR TITLE
Fix Axios error handler typing

### DIFF
--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -1,3 +1,5 @@
+import type { AxiosError } from 'axios';
+
 export interface ApiError {
   message: string;
   code?: string;
@@ -8,7 +10,7 @@ export const handleApiError = (error: unknown): ApiError => {
   if (typeof error === 'object' && error !== null && (error as AxiosError).isAxiosError === true) {
     const axiosError = error as AxiosError;
     const status = axiosError.response?.status;
-    const data = axiosError.response?.data;
+    const data: any = axiosError.response?.data;
 
     // Handle specific HTTP status codes
     switch (status) {
@@ -91,4 +93,3 @@ export const handleApiError = (error: unknown): ApiError => {
     details: error,
   };
 };
-import type { AxiosError } from 'axios';


### PR DESCRIPTION
## Summary
- move axios import to the top of `apiErrorHandler`
- type `data` as `any` so optional chaining on `message` is allowed

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:unit` *(fails: deno not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f88a56e4832db787a8b9421a3806