### PR TITLE
Fix Playwright config for Vite ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ src/
 - `npm run lint` - Run ESLint
 - `npm run preview` - Preview production build
 - `npm run test:e2e` - Run Playwright end-to-end tests
+  - The command spins up the Vite dev server automatically. Set `BASE_URL` if you
+    want to point the tests at a different running instance.
+  - Browsers are downloaded on first run; reuse of the dev server is disabled in
+    CI when the `CI` environment variable is present.
+  - Ensure a valid `.env` file is present so Vite can read the Supabase keys.
 
 ## Realtime Experience
 

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "types": ["@playwright/test"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:5173',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'vite dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } }
+  ],
+  reporter: process.env.CI ? 'dot' : 'list',
+  tsconfig: './e2e/tsconfig.json'
+});


### PR DESCRIPTION
## Summary
- configure Playwright to run under Vite's ESM setup
- add ESM-friendly tsconfig for e2e tests
- document BASE_URL and `.env` requirements for `npm run test:e2e`

## Testing
- `npm run test:e2e` *(fails: Login page not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f88b9688832db6ce1a2af76e1e1a