### PR TITLE
Fix friend invite link generation

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -274,7 +274,7 @@ const Account = () => {
     setInviteError(null);
     try {
       const token = uuidv4();
-      const { error } = await supabase.from('friend_invites').insert({ inviter_id: user.id, token });
+      const { error } = await supabase.from('friend_invites').insert({ inviter_id: user.id, token, invitee_email: null as unknown as string });
       if (error) {
         setInviteError(t('account.inviteError', 'Kon uitnodigingslink niet genereren. Probeer het opnieuw.'));
       } else {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -110,7 +110,7 @@ export interface Notification {
 export interface FriendInvite {
   id: string;
   inviter_id: string;
-  invitee_email: string;
+  invitee_email?: string | null;
   token: string;
   created_at: string;
   accepted: boolean;

--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -10,7 +10,7 @@ export const handleApiError = (error: unknown): ApiError => {
   if (typeof error === 'object' && error !== null && (error as AxiosError).isAxiosError === true) {
     const axiosError = error as AxiosError;
     const status = axiosError.response?.status;
-    const data: any = axiosError.response?.data;
+    const data = axiosError.response?.data as unknown;
 
     // Handle specific HTTP status codes
     switch (status) {


### PR DESCRIPTION
## Summary
- allow `invitee_email` to be optional in `FriendInvite`
- include `invitee_email: null` when creating invite links
- adjust API error handler to satisfy lint rules

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684494b83fd0832da64ee667cd4be607