### PR TITLE
Handle optional invite email

### DIFF
--- a/src/utils/apiErrorHandler.ts
+++ b/src/utils/apiErrorHandler.ts
@@ -16,8 +16,9 @@ export const handleApiError = (error: unknown): ApiError => {
     switch (status) {
       case 400:
         return {
-          message: (typeof data === 'object' && data !== null && 'message' in data && typeof (data as any).message === 'string'
-            ? (data as any).message
+          message: (typeof data === 'object' && data !== null && 'message' in data &&
+            typeof (data as Record<string, unknown>).message === 'string'
+            ? (data as { message: string }).message
             : 'errors.validation.invalid_request'),
           code: 'BAD_REQUEST',
           details: data,


### PR DESCRIPTION
## Summary
- allow `invitee_email` to be optional in `send-friend-invite`
- only insert and email when an address is provided
- fix lint errors in `apiErrorHandler`

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684748192498832db07ef7a254201c3d