### PR TITLE
Sanitize ICS calendar strings

### DIFF
--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -4,6 +4,11 @@ function encodeBase64(str: string) {
   return btoa(unescape(encodeURIComponent(str)));
 }
 
+function sanitizeICSText(text: string) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\u0000-\u001F\u007F]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 async function wantsReminders(
   supabase: ReturnType<typeof createClient>,
   email: string,
@@ -210,7 +215,7 @@ export async function handleConfirmation(req: Request): Promise<Response> {
       new Date().toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
 
     const ics =
-      `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtStamp}\nSUMMARY:Koffie Meetup\nDTSTART:${datePart}${dtStart}\nDTEND:${datePart}${dtEnd}\nDESCRIPTION:Jullie koffie-afspraak!\nLOCATION:${cafe.name} ${cafe.address}\nEND:VEVENT\nEND:VCALENDAR`;
+      `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtStamp}\nSUMMARY:Koffie Meetup\nDTSTART:${datePart}${dtStart}\nDTEND:${datePart}${dtEnd}\nDESCRIPTION:Jullie koffie-afspraak!\nLOCATION:${sanitizeICSText(cafe.name)} ${sanitizeICSText(cafe.address)}\nEND:VEVENT\nEND:VCALENDAR`;
     const icsBase64 = encodeBase64(ics);
 
     const cafeImageUrl = cafe.image_url ||

--- a/supabase/functions/send-meeting-reminders/index.ts
+++ b/supabase/functions/send-meeting-reminders/index.ts
@@ -4,6 +4,11 @@ function encodeBase64(str: string) {
   return btoa(unescape(encodeURIComponent(str)));
 }
 
+function sanitizeICSText(text: string) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\u0000-\u001F\u007F]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 async function wantsReminders(
   supabase: ReturnType<typeof createClient>,
   email: string,
@@ -144,7 +149,7 @@ export async function handleReminders(): Promise<Response> {
     const datePart = inv.selected_date.replace(/-/g, "");
     const [_, dtEnd] = slots[slot] || slots["morning"];
     const ics =
-      `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Koffie Meetup\nDTSTART:${datePart}${dtStart}\nDTEND:${datePart}${dtEnd}\nDESCRIPTION:Jullie koffie-afspraak!\nLOCATION:${cafe.name} ${cafe.address}\nEND:VEVENT\nEND:VCALENDAR`;
+      `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Koffie Meetup\nDTSTART:${datePart}${dtStart}\nDTEND:${datePart}${dtEnd}\nDESCRIPTION:Jullie koffie-afspraak!\nLOCATION:${sanitizeICSText(cafe.name)} ${sanitizeICSText(cafe.address)}\nEND:VEVENT\nEND:VCALENDAR`;
     const cafeImageUrl = cafe.image_url ||
       `https://source.unsplash.com/600x300/?coffee,${
         encodeURIComponent(cafe.name)


### PR DESCRIPTION
## Summary
- add `sanitizeICSText` helper to remove control characters
- use it when building `.ics` files in confirmation and reminder functions
- run lint and unit tests

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: deno not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474d1e9418832db88212811aa9d4cd