### PR TITLE
Escape HTML in emails

### DIFF
--- a/supabase/functions/send-friend-invite/index.ts
+++ b/supabase/functions/send-friend-invite/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { escapeHtml } from "../utils.ts";
 
 function getUUID() {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -135,38 +136,41 @@ export async function handleFriendInvite(req: Request): Promise<Response> {
     // @ts-expect-error Deno globals are available in Edge Functions
     const inviteLink = `${Deno.env.get("PUBLIC_SITE_URL") || "https://anemimeets.com"}/invite-friend/${token}`;
     const siteUrl = inviteLink.split('/invite-friend/')[0];
+    const safeName = escapeHtml(inviter.fullName || (isEnglish ? "A friend" : "Een vriend"));
     const subject = isEnglish
-      ? `${inviter.fullName || "A friend"} invited you for coffee on Anemi Meets! ☕️`
-      : `${inviter.fullName || "Een vriend"} heeft je uitgenodigd op Anemi Meets! ☕️`;
+      ? `${safeName} invited you for coffee on Anemi Meets! ☕️`
+      : `${safeName} heeft je uitgenodigd op Anemi Meets! ☕️`;
+    const safeInviteLink = escapeHtml(inviteLink);
+    const safeSiteUrl = escapeHtml(siteUrl);
     const html = isEnglish
       ? `
-        <h2>☕️ ${inviter.fullName || "A friend"} wants to connect with you on Anemi Meets!</h2>
+        <h2>☕️ ${safeName} wants to connect with you on Anemi Meets!</h2>
         <p>Hi there!<br><br>
-        <b>${inviter.fullName || "A friend"}</b> thinks you're awesome and wants to be friends on <b>Anemi Meets</b>.<br>
+        <b>${safeName}</b> thinks you're awesome and wants to be friends on <b>Anemi Meets</b>.<br>
         <br>
-        <a href="${inviteLink}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;border-radius:8px;text-decoration:none;font-weight:bold;margin-top:16px;">Accept Invite & Become Friends</a>
+        <a href="${safeInviteLink}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;border-radius:8px;text-decoration:none;font-weight:bold;margin-top:16px;">Accept Invite & Become Friends</a>
         <br><br>
         <b>Why did you get this invite?</b><br>
         Someone you know wants to connect, plan meetups, and share good times!<br><br>
         <b>What is Anemi Meets?</b><br>
         Anemi Meets is the easiest way to plan real-life coffee meetups with friends. No endless group chats, just pick a time and meet up! 100% free, privacy-friendly, and made for real connections.<br><br>
-        Curious? <a href="${siteUrl}">${siteUrl}</a>
+        Curious? <a href="${safeSiteUrl}">${safeSiteUrl}</a>
         <br><br>
         See you soon! ☕️✨
         </p>
       `
       : `
-        <h2>☕️ ${inviter.fullName || "Een vriend"} wil met je verbinden op Anemi Meets!</h2>
+        <h2>☕️ ${safeName} wil met je verbinden op Anemi Meets!</h2>
         <p>Hoi!<br><br>
-        <b>${inviter.fullName || "Een vriend"}</b> vindt jou gezellig en wil vrienden worden op <b>Anemi Meets</b>.<br>
+        <b>${safeName}</b> vindt jou gezellig en wil vrienden worden op <b>Anemi Meets</b>.<br>
         <br>
-        <a href="${inviteLink}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;border-radius:8px;text-decoration:none;font-weight:bold;margin-top:16px;">Accepteer Uitnodiging & Word Vrienden</a>
+        <a href="${safeInviteLink}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;border-radius:8px;text-decoration:none;font-weight:bold;margin-top:16px;">Accepteer Uitnodiging & Word Vrienden</a>
         <br><br>
         <b>Waarom krijg je deze uitnodiging?</b><br>
         Iemand die je kent wil met je verbinden, samen afspreken en leuke momenten delen!<br><br>
         <b>Wat is Anemi Meets?</b><br>
         Anemi Meets is de makkelijkste manier om echte koffiedates te plannen met vrienden. Geen eindeloze groepsapps, gewoon een tijd kiezen en afspreken! 100% gratis, privacyvriendelijk en gemaakt voor échte connecties.<br><br>
-        Nieuwsgierig? <a href="${siteUrl}">${siteUrl}</a>
+        Nieuwsgierig? <a href="${safeSiteUrl}">${safeSiteUrl}</a>
         <br><br>
         Tot snel! ☕️✨
         </p>

--- a/supabase/functions/send-meeting-confirmation/index.ts
+++ b/supabase/functions/send-meeting-confirmation/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { escapeHtml } from "../utils.ts";
 
 function encodeBase64(str: string) {
   return btoa(unescape(encodeURIComponent(str)));
@@ -229,17 +230,24 @@ export async function handleConfirmation(req: Request): Promise<Response> {
       `https://source.unsplash.com/600x300/?coffee,${
         encodeURIComponent(cafe.name)
       }`;
+    const safeCafeImageUrl = escapeHtml(cafeImageUrl);
     const gcalUrl =
       `https://www.google.com/calendar/render?action=TEMPLATE&text=${
         encodeURIComponent("Koffie Meetup via Anemi")
       }&dates=${datePart}${dtStart}/${datePart}${dtEnd}&location=${
         encodeURIComponent(`${cafe.name} ${cafe.address}`)
       }`;
+    const safeGcalUrl = escapeHtml(gcalUrl);
 
     const nameA = email_a.split("@")[0];
+    const safeNameA = escapeHtml(nameA);
+    const safeCafeName = escapeHtml(cafe.name);
+    const safeCafeAddress = escapeHtml(cafe.address);
+    const safeReadableTime = escapeHtml(readableTime);
+    const safeSelectedDate = escapeHtml(selected_date);
     const subject = isEnglish
-      ? `☕️ ${nameA} just booked coffee with you!`
-      : `☕️ ${nameA} heeft een koffie-date gepland!`;
+      ? `☕️ ${safeNameA} just booked coffee with you!`
+      : `☕️ ${safeNameA} heeft een koffie-date gepland!`;
 
     const html = `
       <h2>${
@@ -247,18 +255,18 @@ export async function handleConfirmation(req: Request): Promise<Response> {
         ? "☕️ Yes! Your coffee meetup is set!"
         : "☕️ Yes! Jullie koffie-date staat!"
     }</h2>
-      <img src="${cafeImageUrl}" alt="Cafe" width="100%" style="max-width:600px;border-radius:12px;" />
+      <img src="${safeCafeImageUrl}" alt="Cafe" width="100%" style="max-width:600px;border-radius:12px;" />
       <p>${isEnglish ? "Hey legends!" : "Hey toppers!"}<br>
       ${
       isEnglish ? "You're meeting at" : "Jullie hebben afgesproken bij"
-    } <b>${cafe.name}</b>.<br>
+    } <b>${safeCafeName}</b>.<br>
       <b>${
       isEnglish ? "Address" : "Adres"
-    }:</b> ${cafe.address}<br>
+    }:</b> ${safeCafeAddress}<br>
       <b>${
       isEnglish ? "Time" : "Tijd"
-    }:</b> ${readableTime} on ${selected_date}</p>
-      <p><a href="${gcalUrl}" target="_blank">➕ ${
+    }:</b> ${safeReadableTime} on ${safeSelectedDate}</p>
+      <p><a href="${safeGcalUrl}" target="_blank">➕ ${
       isEnglish ? "Add to Google Calendar" : "Voeg toe aan Google Calendar"
     }</a></p>`;
 

--- a/supabase/functions/utils.test.ts
+++ b/supabase/functions/utils.test.ts
@@ -1,0 +1,19 @@
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { escapeHtml } from "./utils.ts";
+
+Deno.test("escapeHtml converts special characters", () => {
+  const input = "Tom & Jerry <script>alert('x')</script>";
+  const escaped = escapeHtml(input);
+  assert(!escaped.includes("<script>"));
+  assert(escaped.includes("&lt;script&gt;"));
+  assertEquals(
+    escaped,
+    "Tom &amp; Jerry &lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;",
+  );
+});
+
+Deno.test("escapeHtml prevents script injection in cafe data", () => {
+  const cafeName = "<script>alert('hack')</script> Cafe";
+  const html = `<div>${escapeHtml(cafeName)}</div>`;
+  assert(!html.includes("<script>"));
+});

--- a/supabase/functions/utils.ts
+++ b/supabase/functions/utils.ts
@@ -1,0 +1,9 @@
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+


### PR DESCRIPTION
## Summary
- add HTML escaping utility
- sanitize fields in friend invite and meeting confirmation emails
- cover escaping logic with tests

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:unit` *(fails: error sending request for url due to invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684953024c44832dae183952553d85a9