### PR TITLE
Escape html in reminder emails

### DIFF
--- a/supabase/functions/send-friend-invite/index.test.ts
+++ b/supabase/functions/send-friend-invite/index.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { handleFriendInvite } from "./index.ts";
 
 Deno.test("missing authorization returns 401", async () => {
@@ -32,6 +32,43 @@ Deno.test("inviter mismatch returns 403", async () => {
   }));
 
   assertEquals(res.status, 403);
+  globalThis.fetch = originalFetch;
+});
+
+Deno.test("invite email escapes html", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "key");
+  Deno.env.set("RESEND_API_KEY", "key");
+
+  let html = "";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | URL | string, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/auth/v1/user")) {
+      return new Response(JSON.stringify({ user: { id: "auth-user" } }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/rest/v1/profiles")) {
+      return new Response("[{\"fullName\":\"<b>Hacker</b>\",\"email\":\"hack@example.com\"}]", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/rest/v1/friend_invites")) {
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("resend.com")) {
+      html = JSON.parse(init?.body as string).html;
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+
+  const res = await handleFriendInvite(new Request("http://localhost", {
+    method: "POST",
+    headers: { "Authorization": "Bearer token", "Content-Type": "application/json" },
+    body: JSON.stringify({ invitee_email: "friend@example.com" })
+  }));
+
+  assertEquals(res.status, 200);
+  assert(!html.includes("<b>Hacker</b>"));
+  assert(html.includes("&lt;b&gt;Hacker&lt;/b&gt;"));
   globalThis.fetch = originalFetch;
 });
 

--- a/supabase/functions/send-meeting-reminders/index.test.ts
+++ b/supabase/functions/send-meeting-reminders/index.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
 // Stub Deno.cron to avoid errors when importing the handler
 // deno-lint-ignore no-explicit-any
@@ -12,4 +12,60 @@ Deno.test("missing env vars", async () => {
   Deno.env.delete("RESEND_API_KEY");
   const res = await handleReminders();
   assertEquals(res.status, 500);
+});
+
+Deno.test("reminder email escapes html", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "key");
+  Deno.env.set("RESEND_API_KEY", "key");
+
+  let html = "";
+  const originalFetch = globalThis.fetch;
+
+  const fixedDate = new Date("2024-01-01T06:00:00Z");
+  const RealDate = Date;
+  class FakeDate extends RealDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        return new RealDate(fixedDate);
+      }
+      // @ts-ignore
+      return new RealDate(...args);
+    }
+    static now() { return fixedDate.getTime(); }
+  }
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).Date = FakeDate;
+
+  globalThis.fetch = async (input: Request | URL | string, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/rest/v1/invitations") && (!init || init.method === "GET")) {
+      const data = [{ id: 1, token: "tok", email_a: "a@example.com", email_b: "b@example.com", selected_date: "2024-01-01", selected_time: "morning", cafe_id: 1, reminded_24h: null, reminded_1h: null }];
+      return new Response(JSON.stringify(data), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/rest/v1/cafes")) {
+      const cafe = { name: "<script>bad</script>", address: "<b>Main</b>", image_url: null, opening_hours: { mon: "07:00 – 19:00" } };
+      return new Response(JSON.stringify(cafe), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/auth/v1/admin/users")) {
+      return new Response(JSON.stringify({ users: [{ id: "uid" }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("/rest/v1/profiles")) {
+      return new Response("[{\"wantsReminders\":true}]", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.includes("resend.com")) {
+      html = JSON.parse(init?.body as string).html;
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+  };
+
+  const res = await handleReminders();
+  assertEquals(res.status, 200);
+  assert(!html.includes("<script>bad</script>"));
+  assert(html.includes("&lt;script&gt;bad&lt;/script&gt;"));
+
+  globalThis.fetch = originalFetch;
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).Date = RealDate;
 });

--- a/supabase/functions/send-meeting-reminders/index.ts
+++ b/supabase/functions/send-meeting-reminders/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { escapeHtml } from "../utils.ts";
 
 function encodeBase64(str: string) {
   return btoa(unescape(encodeURIComponent(str)));
@@ -154,15 +155,20 @@ export async function handleReminders(): Promise<Response> {
       `https://source.unsplash.com/600x300/?coffee,${
         encodeURIComponent(cafe.name)
       }`;
+    const safeCafeImageUrl = escapeHtml(cafeImageUrl);
     const readableTime = slotReadable[slot] || slotReadable["morning"];
+    const safeCafeName = escapeHtml(cafe.name);
+    const safeCafeAddress = escapeHtml(cafe.address);
+    const safeReadableTime = escapeHtml(readableTime);
+    const safeSelectedDate = escapeHtml(inv.selected_date);
     const subject = needs1h
       ? `☕️ Your meetup starts in about an hour!`
       : `☕️ Reminder: coffee meetup tomorrow!`;
     const html = `
         <h2>☕️ Your coffee meetup is coming up!</h2>
-        <img src="${cafeImageUrl}" alt="Cafe" width="100%" style="max-width:600px;border-radius:12px;" />
-        <p>You'll meet at <b>${cafe.name}</b> (${cafe.address})</p>
-        <p>Time: ${readableTime} on ${inv.selected_date}</p>`;
+        <img src="${safeCafeImageUrl}" alt="Cafe" width="100%" style="max-width:600px;border-radius:12px;" />
+        <p>You'll meet at <b>${safeCafeName}</b> (${safeCafeAddress})</p>
+        <p>Time: ${safeReadableTime} on ${safeSelectedDate}</p>`;
 
     const recipients: string[] = [];
     if (await wantsReminders(supabase, inv.email_a)) {


### PR DESCRIPTION
## Summary
- sanitize cafe name/address for meeting reminder emails
- test escaping behavior for friend invite and reminder emails

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:unit` *(fails: deno not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de567308832d849c3ff12095037b