### PR TITLE
Clarify Deno.cron ts-expect-error

### DIFF
--- a/supabase/functions/send-meeting-reminders/index.ts
+++ b/supabase/functions/send-meeting-reminders/index.ts
@@ -298,6 +298,6 @@ if (import.meta.main) {
 
 // Guard Deno.cron for local testing
 if ("cron" in Deno) {
-  // @ts-expect-error: Deno.cron is not available in all environments
+  // @ts-expect-error Deno.cron is only available in the Supabase Edge runtime
   Deno.cron("reminder cron job", "0 * * * *", handleReminders);
 }


### PR DESCRIPTION
## Summary
- document why Deno.cron is ignored in TypeScript when running locally

## Testing
- `npm run test:unit` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_685526fc0940832d93eb35606f45d6a5