### PR TITLE
Update README delete-account env

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ All Edge Functions are in `supabase/functions/`. Deploy with the Supabase CLI. M
 #### delete-account
 
 - **Purpose:** Deletes a user from Auth and their profile from the database.
-- **Env:** `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+- **Env:** `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`
 - **Usage:**
   - `POST` with `Authorization: Bearer <JWT>`
   - No body required (user is inferred from JWT)


### PR DESCRIPTION
## Summary
- clarify environment variables for the delete-account function

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*
- `npm run test:unit` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685532719314832d8b082cd7616b1005