### PR TITLE
Fix invitation column naming

### DIFF
--- a/supabase/migrations/0003_create_tables_and_views.sql
+++ b/supabase/migrations/0003_create_tables_and_views.sql
@@ -103,8 +103,8 @@ CREATE TABLE public.friendships (
 
 CREATE TABLE public.invitations (
     id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
-    sender_id uuid NOT NULL,
-    receiver_id uuid,
+    inviter_id uuid NOT NULL,
+    invitee_id uuid,
     meetup_date timestamp with time zone NOT NULL,
     status public.invitation_status DEFAULT 'pending'::public.invitation_status NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,

--- a/supabase/migrations/0005_add_rls_policies_and_triggers.sql
+++ b/supabase/migrations/0005_add_rls_policies_and_triggers.sql
@@ -32,11 +32,11 @@ ALTER TABLE public.invitations ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Allow guest to view invitation by token" ON public.invitations FOR SELECT TO anondummy, authenticated USING ((token)::text = (current_setting('request.headers'::text, true))::jsonb ->> 'x-invitation-token'::text));
 
-CREATE POLICY "Allow users to delete their own invitations" ON public.invitations FOR DELETE USING ((auth.uid() = sender_id));
+CREATE POLICY "Allow users to delete their own invitations" ON public.invitations FOR DELETE USING ((auth.uid() = inviter_id));
 
-CREATE POLICY "Allow users to read invitations they are involved in" ON public.invitations FOR SELECT USING (((auth.uid() = sender_id) OR (auth.uid() = receiver_id)));
+CREATE POLICY "Allow users to read invitations they are involved in" ON public.invitations FOR SELECT USING (((auth.uid() = inviter_id) OR (auth.uid() = invitee_id)));
 
-CREATE POLICY "Allow users to update their own invitations" ON public.invitations FOR UPDATE USING ((auth.uid() = sender_id)) WITH CHECK ((auth.uid() = sender_id));
+CREATE POLICY "Allow users to update their own invitations" ON public.invitations FOR UPDATE USING ((auth.uid() = inviter_id)) WITH CHECK ((auth.uid() = inviter_id));
 
 CREATE POLICY "Enable insert for authenticated users only" ON public.invitations FOR INSERT TO authenticated WITH CHECK (true);
 


### PR DESCRIPTION
## Summary
- rename invitation columns in migration
- update RLS policies to use new names

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:unit` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c950f08c832dbb565d78372d01d7