### PR TITLE
Implement friend invite acceptance

### DIFF
--- a/supabase/functions/accept-friend-invite/index.test.ts
+++ b/supabase/functions/accept-friend-invite/index.test.ts
@@ -7,36 +7,35 @@ Deno.test('accepts invite with valid token and email', async () => {
   // @ts-expect-error Deno global is available in Deno tests
   Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'key');
 
-  // Mock fetch for Supabase client
   const originalFetch = globalThis.fetch;
+  let updated = false;
+  let upserted = false;
   globalThis.fetch = async (input: Request | URL | string, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
     if (url.includes('/auth/v1/user')) {
-      return new Response(JSON.stringify({ user: { id: 'user-b', email: 'friend@example.com' } }), {
-        status: 200,
-      });
+      return new Response(JSON.stringify({ user: { id: 'user-b', email: 'friend@example.com' } }), { status: 200 });
     }
-    if (url.includes('/rest/v1/friend_invites')) {
+    if (url.includes('/rest/v1/friend_invites') && (!init || init.method === 'GET')) {
       return new Response(
         JSON.stringify([
           {
             id: 'invite-1',
             inviter_id: 'user-a',
+            invitee_email: 'friend@example.com',
             status: 'pending',
-            expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
           },
         ]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     }
-    if (url.includes('/rest/v1/rpc/accept_friend_invite')) {
-      return new Response(
-        JSON.stringify({
-          success: true,
-          friendship_created: true,
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      );
+    if (url.includes('/rest/v1/friend_invites') && init?.method === 'PATCH') {
+      updated = true;
+      return new Response(JSON.stringify([{ id: 'invite-1' }]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (url.includes('/rest/v1/friendships')) {
+      upserted = true;
+      return new Response(JSON.stringify([{ id: 'f1' }]), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }
     return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
@@ -53,7 +52,8 @@ Deno.test('accepts invite with valid token and email', async () => {
   assertEquals(res.status, 200);
   const body = await res.json();
   assertEquals(body.success, true);
-  assertEquals(body.friendship_created, true);
+  assertEquals(updated, true);
+  assertEquals(upserted, true);
 
   globalThis.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- implement logic for accepting friend invites
- mark invite as accepted and create friendships
- update unit tests for the new implementation

## Testing
- `npm run test:unit` *(fails: deno not found)*
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6857dac14f20832dba4587d224f0319e