### PR TITLE
Add verified cafe popup

### DIFF
--- a/src/features/meetups/components/README.md
+++ b/src/features/meetups/components/README.md
@@ -3,6 +3,8 @@
 This folder contains UI components specific to the meetups feature of Anemi Meets.
 
 ## Components
-- `DateSelector.tsx`: Allows users to select and propose dates for meetups.
 
-Add new meetups-specific components here as the feature evolves. 
+- `DateSelector.tsx`: Allows users to select and propose dates for meetups.
+- `VerifiedCafePopup.tsx`: Modal showing extra info for verified cafés.
+
+Add new meetups-specific components here as the feature evolves.

--- a/src/features/meetups/components/VerifiedCafePopup.tsx
+++ b/src/features/meetups/components/VerifiedCafePopup.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface VerifiedCafePopupProps {
+  cafe: {
+    id?: string;
+    name: string;
+    story?: string | null;
+    specialty?: string | null;
+    mission?: string | null;
+    image_url?: string | null;
+  };
+  open: boolean;
+  onClose: () => void;
+}
+
+const VerifiedCafePopup: React.FC<VerifiedCafePopupProps> = ({ cafe, open, onClose }) => {
+  const { t } = useTranslation();
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6 relative" tabIndex={0}>
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-500 hover:text-primary-700 text-2xl"
+          aria-label={t('close') || 'Close'}
+        >
+          ×
+        </button>
+        {cafe.image_url && (
+          <img
+            src={cafe.image_url}
+            alt={cafe.name}
+            className="w-full h-40 object-cover rounded-lg mb-4"
+          />
+        )}
+        <h2 className="text-xl font-bold text-primary-700 mb-2">{cafe.name}</h2>
+        {cafe.story && <p className="text-gray-700 mb-4 whitespace-pre-line">{cafe.story}</p>}
+        {cafe.specialty && (
+          <p className="mb-2">
+            <span className="font-semibold">{t('verifiedCafe.specialty')}:</span> {cafe.specialty}
+          </p>
+        )}
+        {cafe.mission && (
+          <p className="mb-4">
+            <span className="font-semibold">{t('verifiedCafe.mission')}:</span> {cafe.mission}
+          </p>
+        )}
+        <a href="/cafe-details" className="btn-secondary w-full text-center">
+          {t('verifiedCafe.viewStory')}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default VerifiedCafePopup;

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '../supabaseClient';
 import SkeletonLoader from '../components/SkeletonLoader';
+import VerifiedCafePopup from '../features/meetups/components/VerifiedCafePopup';
 
 type InvitationWithCafe = {
   selected_date: string;
@@ -10,6 +11,11 @@ type InvitationWithCafe = {
   cafe_id?: string;
   cafe_name?: string;
   cafe_address?: string;
+  cafe_verified?: boolean | null;
+  cafe_story?: string | null;
+  cafe_specialty?: string | null;
+  cafe_mission?: string | null;
+  cafe_image_url?: string | null;
   date_time_options?: { date: string; times: string[] }[];
 };
 
@@ -23,6 +29,7 @@ const Invite = () => {
   const [error, setError] = useState<string | null>(null);
   const [canShare, setCanShare] = useState(false);
   const [detailsLoading, setDetailsLoading] = useState(false);
+  const [showVerifiedPopup, setShowVerifiedPopup] = useState(false);
 
   useEffect(() => {
     // Check if Web Share API is available
@@ -58,12 +65,17 @@ const Invite = () => {
             if (inviteData.cafe_id) {
               const { data: cafeData, error: cafeError } = await supabase
                 .from('cafes')
-                .select('name, address')
+                .select('name, address, verified, story, specialty, mission, image_url')
                 .eq('id', inviteData.cafe_id)
                 .maybeSingle();
               if (!cafeError && cafeData) {
                 (inviteData as InvitationWithCafe).cafe_name = cafeData.name;
                 (inviteData as InvitationWithCafe).cafe_address = cafeData.address;
+                (inviteData as InvitationWithCafe).cafe_verified = cafeData.verified;
+                (inviteData as InvitationWithCafe).cafe_story = cafeData.story;
+                (inviteData as InvitationWithCafe).cafe_specialty = cafeData.specialty;
+                (inviteData as InvitationWithCafe).cafe_mission = cafeData.mission;
+                (inviteData as InvitationWithCafe).cafe_image_url = cafeData.image_url;
               }
             }
             setInvitation(inviteData as InvitationWithCafe);
@@ -160,6 +172,15 @@ const Invite = () => {
             <span className="font-bold text-xl">
               {invitation.cafe_name || t('invite.cafeInfoPending', 'Café will be revealed soon!')}
             </span>
+            {invitation.cafe_verified && (
+              <button
+                type="button"
+                onClick={() => setShowVerifiedPopup(true)}
+                className="text-green-600 text-xs underline"
+              >
+                ✓ Verified
+              </button>
+            )}
             {invitation.cafe_address && (
               <span className="text-gray-700">{invitation.cafe_address}</span>
             )}
@@ -263,6 +284,19 @@ const Invite = () => {
             <div className="text-red-600 mt-2">{t('invite.copyError')}</div>
           )}
         </>
+      )}
+      {invitation && invitation.cafe_verified && (
+        <VerifiedCafePopup
+          cafe={{
+            name: invitation.cafe_name || '',
+            story: invitation.cafe_story || undefined,
+            specialty: invitation.cafe_specialty || undefined,
+            mission: invitation.cafe_mission || undefined,
+            image_url: invitation.cafe_image_url || undefined,
+          }}
+          open={showVerifiedPopup}
+          onClose={() => setShowVerifiedPopup(false)}
+        />
       )}
     </div>
   );

--- a/src/pages/Respond.tsx
+++ b/src/pages/Respond.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from '../components/LoadingIndicator';
 import FormStatus from '../components/FormStatus';
 import { Database } from '../types/supabase';
 import { isDateTimeOptions } from '../utils/typeGuards';
+import VerifiedCafePopup from '../features/meetups/components/VerifiedCafePopup';
 
 type Invitation = Database['public']['Tables']['invitations']['Row'];
 type Cafe = Database['public']['Tables']['cafes']['Row'];
@@ -32,6 +33,7 @@ const Respond = () => {
   const [submitted, setSubmitted] = useState(false);
   const [confirmationInfo, setConfirmationInfo] = useState<ConfirmationInfo | null>(null);
   const UPDATES_EMAIL_KEY = 'anemi-updates-email';
+  const [showVerifiedPopup, setShowVerifiedPopup] = useState(false);
 
   useEffect(() => {
     const savedEmail = localStorage.getItem(UPDATES_EMAIL_KEY);
@@ -230,7 +232,18 @@ const Respond = () => {
         )}
         {cafe && cafe.name ? (
           <>
-            <p className="text-gray-700 font-medium">{cafe.name}</p>
+            <p className="text-gray-700 font-medium flex items-center gap-2">
+              {cafe.name}
+              {cafe.verified && (
+                <button
+                  type="button"
+                  onClick={() => setShowVerifiedPopup(true)}
+                  className="text-green-600 text-xs underline"
+                >
+                  ✓ Verified
+                </button>
+              )}
+            </p>
             {cafe.address && <p className="text-gray-500">{cafe.address}</p>}
           </>
         ) : invitation && invitation.cafe_id ? (
@@ -329,6 +342,19 @@ const Respond = () => {
           message={confirmationInfo ? (t('respond.success') as string) || '' : error || ''}
         />
       </form>
+      {cafe && cafe.verified && (
+        <VerifiedCafePopup
+          cafe={{
+            name: cafe.name,
+            story: cafe.story || undefined,
+            specialty: cafe.specialty || undefined,
+            mission: cafe.mission || undefined,
+            image_url: cafe.image_url || undefined,
+          }}
+          open={showVerifiedPopup}
+          onClose={() => setShowVerifiedPopup(false)}
+        />
+      )}
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- add `VerifiedCafePopup` modal component for meeting pages
- fetch extra cafe fields for invitation data
- show 'Verified' badge on meeting pages linking to popup

## Testing
- `npm run lint` *(fails: @eslint/eslintrc missing)*
- `npm run test:components` *(fails: existing tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6857dac26380832d90e49c64d16aee22