### PR TITLE
Fix build errors, add badge service

### DIFF
--- a/src/components/BetaSignup.test.tsx
+++ b/src/components/BetaSignup.test.tsx
@@ -7,9 +7,9 @@ import BetaSignup from './BetaSignup';
 vi.mock('../supabaseClient', () => ({
   supabase: {
     from: vi.fn(() => ({
-      insert: vi.fn().mockResolvedValue({ data: null, error: null })
-    }))
-  }
+      insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  },
 }));
 
 // Mock react-i18next
@@ -25,13 +25,14 @@ vi.mock('react-i18next', () => ({
         'betaSignup.sending': 'Joining...',
         'betaSignup.success': "You're on the list! We'll let you know when you can join.",
         'betaSignup.error': 'Oops! Something went wrong. Please try again.',
-        'betaSignup.alreadyOnList': "You're already on the waitlist! We'll let you know when you can join.",
+        'betaSignup.alreadyOnList':
+          "You're already on the waitlist! We'll let you know when you can join.",
         'betaSignup.invalidEmail': 'Please enter a valid email address.',
-        'close': 'Close'
+        close: 'Close',
       };
       return translations[key] || key;
-    }
-  })
+    },
+  }),
 }));
 
 describe('BetaSignup', () => {
@@ -64,18 +65,19 @@ describe('BetaSignup', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent("You're on the list! We'll let you know when you can join.");
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "You're on the list! We'll let you know when you can join.",
+      );
     });
   });
 
   it('handles duplicate email error', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(supabase.from).mockReturnValue({
       insert: vi.fn().mockResolvedValue({
         data: null,
         error: { message: 'duplicate key value violates unique constraint' },
       }),
-    } as any);
+    } as unknown as ReturnType<typeof supabase.from>);
 
     const input = screen.getByRole('textbox');
     const submitButton = screen.getByRole('button');
@@ -84,18 +86,19 @@ describe('BetaSignup', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent("You're already on the waitlist! We'll let you know when you can join.");
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "You're already on the waitlist! We'll let you know when you can join.",
+      );
     });
   });
 
   it('handles API error', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(supabase.from).mockReturnValue({
       insert: vi.fn().mockResolvedValue({
         data: null,
         error: { message: 'Internal server error' },
       }),
-    } as any);
+    } as unknown as ReturnType<typeof supabase.from>);
 
     const input = screen.getByRole('textbox');
     const submitButton = screen.getByRole('button');
@@ -104,7 +107,9 @@ describe('BetaSignup', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Oops! Something went wrong. Please try again.');
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Oops! Something went wrong. Please try again.',
+      );
     });
   });
-}); 
+});

--- a/src/components/ReportIssueModal.tsx
+++ b/src/components/ReportIssueModal.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { supabase } from '../supabaseClient';
+// import { supabase } from '../supabaseClient';
 // import { awardBadge } from '../services/badgeService';
-import FormStatus from './FormStatus';
 
 interface Props {
   open: boolean;
@@ -19,7 +18,6 @@ const ReportIssueModal: React.FC<Props> = ({ open, onClose }) => {
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
   if (!open) return null;
 
@@ -83,7 +81,6 @@ const ReportIssueModal: React.FC<Props> = ({ open, onClose }) => {
       //   setStatus(null);
       // }, 3000);
 
-      setLoading(false);
       onClose();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Onbekende fout';

--- a/src/pages/InviteFriend.tsx
+++ b/src/pages/InviteFriend.tsx
@@ -59,6 +59,7 @@ export default function InviteFriend(): JSX.Element {
     if (!invite) return;
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error } = await supabase.rpc('accept_friend_invite' as any, { token });
 
       if (error) throw error;

--- a/src/pages/Meetups.tsx
+++ b/src/pages/Meetups.tsx
@@ -5,17 +5,16 @@ import { useTranslation } from 'react-i18next';
 import Toast from '../components/Toast';
 import { getMeetupCount } from '../services/invitationService';
 import { Database } from '../types/supabase';
-import { useAuth } from '../hooks/useAuth';
-import type { Meetup, Profile } from '../types/supabase';
+import { hasBadge, awardBadge } from '../services/badgeService';
 
-type Meetup = Database['public']['Tables']['invitations']['Row'];
+type MeetupRow = Database['public']['Tables']['invitations']['Row'];
 
 const LOCAL_CACHE_KEY = 'meetups_cache_v1';
 
 import type { TFunction } from 'i18next';
 
 interface MeetupListItemProps {
-  meetup: Meetup;
+  meetup: MeetupRow;
   onView: (id: string) => void;
   onJoin: (id: string) => void;
   t: TFunction;
@@ -119,7 +118,7 @@ const MeetupListItem = React.memo(function MeetupListItem({
 const Meetups: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation(['meetups', 'common']);
-  const [meetups, setMeetups] = useState<Meetup[]>([]);
+  const [meetups, setMeetups] = useState<MeetupRow[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState('all');
   const [loading, setLoading] = useState(true);

--- a/src/services/badgeService.ts
+++ b/src/services/badgeService.ts
@@ -1,0 +1,30 @@
+import { supabase } from '../supabaseClient';
+import type { Database } from '../types/supabase';
+
+export type UserBadgeRow = Database['public']['Tables']['user_badges']['Row'];
+
+export async function hasBadge(userId: string, badgeKey: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('user_badges')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('badge_key', badgeKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error checking badge:', error);
+    return false;
+  }
+
+  return !!data;
+}
+
+export async function awardBadge(userId: string, badgeKey: string): Promise<void> {
+  const { error } = await supabase
+    .from('user_badges')
+    .insert({ user_id: userId, badge_key: badgeKey });
+
+  if (error) {
+    console.error('Error awarding badge:', error);
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { resolve } from 'path';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -12,8 +13,13 @@ export default defineConfig(({ mode }) => {
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: 'anemi',
         project: 'javascript-react',
-      })
+      }),
     ],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+      },
+    },
     build: {
       outDir: 'dist',
       sourcemap: true,


### PR DESCRIPTION
## Summary
- remove unused imports and state from `ReportIssueModal`
- introduce `badgeService` for badge checks and awards
- wire badge service into `Meetups`
- adjust tests and invite handling for lint compliance
- add Vite alias for `@` to fix build

## Testing
- `npx eslint "src/**/*.{ts,tsx}" "e2e/**/*.ts" --report-unused-disable-directives --max-warnings 0`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685823a86cfc832d9de59f3023ea85c9