### PR TITLE
Fix CORS headers for solo-adventure edge function

### DIFF
--- a/supabase/functions/schedule-solo-adventure/index.ts
+++ b/supabase/functions/schedule-solo-adventure/index.ts
@@ -4,6 +4,7 @@ import type { Database } from '../../../src/types/supabase.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 // Utility to escape HTML


### PR DESCRIPTION
## Summary
- allow POST requests through CORS preflight for `schedule-solo-adventure`

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run test:unit` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859145a3eac832dae4d868c78e5b8c3