### PR TITLE
Add env var validation for schedule adventure function

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,10 +1,11 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '../../utils/cn';
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
   'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
@@ -36,7 +37,7 @@ export interface ButtonProps
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
@@ -45,5 +46,3 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   },
 );
 Button.displayName = 'Button';
-
-export { Button, buttonVariants };

--- a/src/context/OnboardingContext.tsx
+++ b/src/context/OnboardingContext.tsx
@@ -1,13 +1,5 @@
-import React, { useState, useEffect, useContext } from 'react';
-import { OnboardingContext } from './onboarding';
-
-export const useOnboarding = () => {
-  const context = useContext(OnboardingContext);
-  if (!context) {
-    throw new Error('useOnboarding must be used within an OnboardingProvider');
-  }
-  return context;
-};
+import React, { useState, useEffect } from 'react';
+import { OnboardingContext, useOnboarding } from './onboarding';
 
 export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isOnboardingComplete, setIsOnboardingComplete] = useState(false);
@@ -49,3 +41,6 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     </OnboardingContext.Provider>
   );
 };
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { useOnboarding };

--- a/supabase/functions/schedule-solo-adventure/index.ts
+++ b/supabase/functions/schedule-solo-adventure/index.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import type { Database } from '../../../src/types/supabase.ts';
+import { validateEnvVars } from '../utils.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -36,6 +37,7 @@ async function handler(req: Request) {
   }
 
   try {
+    validateEnvVars(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'RESEND_API_KEY']);
     // Environment variables
     const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
     const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;


### PR DESCRIPTION
## Summary
- validate required environment vars in `schedule-solo-adventure`
- silence React Refresh rule in `button.tsx`
- export `useOnboarding` from provider context

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68599146a5f0832da09cc4286d8857cf