### PR TITLE
Remove side-effect code from utils

### DIFF
--- a/supabase/functions/utils.ts
+++ b/supabase/functions/utils.ts
@@ -184,20 +184,3 @@ export async function sendEmail(options: {
     throw new AppError('Failed to send email', ERROR_CODES.EMAIL_ERROR, 500, await res.text());
   }
 }
-
-// @ts-expect-error Deno global is available in Edge Functions
-Deno.serve(async (req: Request) => {
-  // ...
-});
-
-/* supabase/functions/accept-friend-invite/index.ts */
-// @ts-expect-error Deno global is available in Edge Functions
-const supabaseAdmin = createClient(
-  Deno.env.get('SUPABASE_URL') ?? '',
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-);
-
-// @ts-expect-error Deno global is available in Edge Functions
-Deno.serve(async (req) => {
-  // ...
-});


### PR DESCRIPTION
## Summary
- strip example Serve code from `supabase/functions/utils.ts`
- keep file purely exportable utilities

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859960f6544832db79ba4ab21d6c22c