### PR TITLE
docs: clarify type generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To run this project locally, you need to set up your environment variables:
    npm run gen:types
    ```
    This requires the Supabase CLI to be installed and linked to this project with `supabase link`.
-   The command outputs `src/types/supabase.ts` (and after implementing Issue 1, also `supabase/src/types/supabase.ts`).
+   The command generates `src/types/supabase.ts` and copies it to `supabase/src/types/supabase.ts`.
 
 Note: The `.env` file is intentionally gitignored for security. Never commit your API keys to version control!
 


### PR DESCRIPTION
## Summary
- clarify that `npm run gen:types` generates the types and copies them to the Supabase function directory

## Testing
- `grep -n "supabase.ts" README.md`

------
https://chatgpt.com/codex/tasks/task_e_685996133500832d9db8e74f89962062