### PR TITLE
Fix age type mismatch in Account page

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -190,12 +190,7 @@ function Account() {
         <EditableField
           label={t('account.age', 'Leeftijd')}
           value={profile.age}
-          onSave={(value) =>
-            updateProfile(
-              { age: value === '' ? null : Number(value) },
-              'Je leeftijd is bijgewerkt.',
-            )
-          }
+          onSave={(value) => updateProfile({ age: value }, 'Je leeftijd is bijgewerkt.')}
         />
         <EditableField
           label={t('account.bio', 'Bio')}


### PR DESCRIPTION
## Summary
- pass age as a string when saving user profile

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:components` *(fails: `Test Files  2 failed | 1 passed`)*

------
https://chatgpt.com/codex/tasks/task_e_685a762634bc832d90c2adcea77b0d4d